### PR TITLE
feat: check jwt token signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "require": {
+    "firebase/php-jwt": "^6.10"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,72 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2500b422652843a7421e33662e671525",
-    "packages": [],
+    "content-hash": "7e53dea6b75aca125558da3bd75c8552",
+    "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/500501c2ce893c824c801da135d02661199f60c5",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.1"
+            },
+            "time": "2024-05-18T18:05:11+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
@@ -2273,5 +2337,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -157,7 +157,11 @@ class Google_Jwt {
 		} catch ( \Firebase\JWT\SignatureInvalidException $e ) {
 			// refresh Google JWKs cache and try again.
 			$jwks    = $this->get_jwks();
+		try {
 			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
+		} catch ( SignatureInvalidException $e ) {
+			return new \WP_Error( 'jwt_error', $e->getMessage() );
+		}
 		} catch ( UnexpectedValueException $e ) {
 			return new \WP_Error( 'jwt_error', $e->getMessage() );
 		}

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -159,7 +159,7 @@ class Google_Jwt {
 			$jwks    = $this->get_jwks();
 			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
 		} catch ( UnexpectedValueException $e ) {
-			return new WP_Error( 'jwt_error', $e->getMessage() );
+			return new \WP_Error( 'jwt_error', $e->getMessage() );
 		}
 
 		// Validate the token.

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -154,7 +154,7 @@ class Google_Jwt {
 		}
 		try {
 			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
-		} catch ( SignatureInvalidException $e ) {
+		} catch ( \Firebase\JWT\SignatureInvalidException $e ) {
 			// refresh Google JWKs cache and try again.
 			$jwks    = $this->get_jwks();
 			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Handles Google HWE token verification
+ *
+ * @package Newspack\ExtendedAccess
+ */
+
+namespace Newspack\ExtendedAccess;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
+use UnexpectedValueException;
+
+/**
+ * Class responsible for verifying Google JWT tokens.
+ *
+ * It fetches and caches Google JWKs, and uses them to verify the JWT token.
+ *
+ * Cache is refreshed anytime a signature verification fails, but only if it's older than 5 minutes to avoid abuse.
+ */
+class Google_Jwt {
+
+	/**
+	 * The name of the option where we store the Google JWKs.
+	 *
+	 * @var string
+	 */
+	const CACHE_OPTION_NAME = 'newspack_extended_access_google_jwk';
+
+	/**
+	 * The name of the option where we store the Google JWKs cache creation timestamp.
+	 *
+	 * @var string
+	 */
+	const CACHE_TIMESTAMP_OPTION_NAME = 'newspack_extended_access_google_jwk_timestamp';
+
+	/**
+	 * The URL where we can find the Google OpenID configuration.
+	 *
+	 * @var string
+	 */
+	const GOOGLE_CONFIG_URL = 'https://accounts.google.com/.well-known/openid-configuration';
+
+	/**
+	 * The raw string with the received JWT token.
+	 *
+	 * @var string
+	 */
+	private $payload;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $payload The raw string with the received JWT token.
+	 */
+	public function __construct( $payload ) {
+		$this->payload = $payload;
+	}
+
+	/**
+	 * Get the JWKS URI from Google OpenID configuration.
+	 *
+	 * @return string|bool The JWKS URI or false if it could not be retrieved.
+	 */
+	public function get_jwks_uri() {
+		$response = wp_remote_get( self::GOOGLE_CONFIG_URL );
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$body   = wp_remote_retrieve_body( $response );
+		$config = json_decode( $body, true );
+		if ( ! isset( $config['jwks_uri'] ) ) {
+			return false;
+		}
+
+		return $config['jwks_uri'];
+	}
+
+	/**
+	 * Get the JWKS from Google and cache them.
+	 *
+	 * @return array|bool The JWKS or false if it could not be retrieved.
+	 */
+	public function get_jwks() {
+		$jwks_uri = $this->get_jwks_uri();
+		if ( ! $jwks_uri ) {
+			return false;
+		}
+
+		$response = wp_remote_get( $jwks_uri );
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$jwks = json_decode( $body, true );
+		if ( ! isset( $jwks['keys'] ) ) {
+			return false;
+		}
+
+		$this->update_jwks_cache( $jwks );
+
+		return $jwks;
+	}
+
+	/**
+	 * Update the JWKS cache.
+	 *
+	 * @param array $value The JWKS to cache.
+	 */
+	public function update_jwks_cache( $value ) {
+		update_option( self::CACHE_OPTION_NAME, $value );
+		update_option( self::CACHE_TIMESTAMP_OPTION_NAME, time() );
+	}
+
+	/**
+	 * Get the JWKS from cache.
+	 *
+	 * @return array|bool The JWKS or false if it could not be retrieved.
+	 */
+	public function get_jwks_cached() {
+		return get_option( self::CACHE_OPTION_NAME, false );
+	}
+
+	/**
+	 * Check if we shoulçd refresh the JWKS cache.
+	 *
+	 * Cache is refreshed anytime a signature verification fails, but only if it's older than 5 minutes to avoid abuse.
+	 */
+	public function should_refresh_jwks_cache() {
+		$timestamp = get_option( self::CACHE_TIMESTAMP_OPTION_NAME, 0 );
+		return time() - $timestamp > 300;
+	}
+
+	/**
+	 * Decode the JWT token.
+	 *
+	 * @return mixed|WP_Error The decoded token or a WP_Error if it could not be decoded.
+	 */
+	public function decode() {
+		$jwks = $this->get_jwks_cached();
+		if ( ! $jwks ) {
+			$jwks = $this->get_jwks();
+		}
+
+		if ( ! $jwks ) {
+			return false;
+		}
+		try {
+			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
+		} catch ( SignatureInvalidException $e ) {
+			// refresh Google JWKs cache and try again.
+			$jwks    = $this->get_jwks();
+			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
+		} catch ( UnexpectedValueException $e ) {
+			return new WP_Error( 'jwt_error', $e->getMessage() );
+		}
+
+		// Validate the token.
+		$token_api_id         = $decoded->azp;
+		$google_client_api_id = get_option( 'newspack_extended_access__google_client_api_id', '' );
+		if ( $token_api_id !== $google_client_api_id ) {
+			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token', 'newspack-extended-access' ), array( 'status' => 403 ) );
+		}
+
+		return $decoded;
+	}
+
+}

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -7,8 +7,8 @@
 
 namespace Newspack\ExtendedAccess;
 
-use Firebase\JWT\JWK;
-use Firebase\JWT\JWT;
+use Firebase\JWT\JWK as Firebase_JWK;
+use Firebase\JWT\JWT as Firebase_JWT;
 use Firebase\JWT\SignatureInvalidException;
 use UnexpectedValueException;
 
@@ -153,15 +153,15 @@ class Google_Jwt {
 			return false;
 		}
 		try {
-			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
-		} catch ( \Firebase\JWT\SignatureInvalidException $e ) {
-			// refresh Google JWKs cache and try again.
-			$jwks    = $this->get_jwks();
-		try {
-			$decoded = \Firebase\JWT\JWT::decode( $this->payload, \Firebase\JWT\JWK::parseKeySet( $jwks ) );
+			$decoded = Firebase_JWT::decode( $this->payload, Firebase_JWK::parseKeySet( $jwks ) );
 		} catch ( SignatureInvalidException $e ) {
-			return new \WP_Error( 'jwt_error', $e->getMessage() );
-		}
+			// refresh Google JWKs cache and try again.
+			$jwks = $this->get_jwks();
+			try {
+				$decoded = Firebase_JWT::decode( $this->payload, Firebase_JWK::parseKeySet( $jwks ) );
+			} catch ( SignatureInvalidException $e ) {
+				return new \WP_Error( 'jwt_error', $e->getMessage() );
+			}
 		} catch ( UnexpectedValueException $e ) {
 			return new \WP_Error( 'jwt_error', $e->getMessage() );
 		}

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -79,11 +79,15 @@ class Google_Jwt {
 	}
 
 	/**
-	 * Get the JWKS from Google and cache them.
+	 * Get the JWKS from Google if the cache is expired and cache them.
 	 *
 	 * @return array|bool The JWKS or false if it could not be retrieved.
 	 */
 	public function get_jwks() {
+		if ( ! $this->should_refresh_jwks_cache() ) {
+			return $this->get_jwks_cached();
+		}
+
 		$jwks_uri = $this->get_jwks_uri();
 		if ( ! $jwks_uri ) {
 			return false;

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -129,7 +129,7 @@ class Google_Jwt {
 	}
 
 	/**
-	 * Check if we shoulçd refresh the JWKS cache.
+	 * Check if we should refresh the JWKS cache.
 	 *
 	 * Cache is refreshed anytime a signature verification fails, but only if it's older than 5 minutes to avoid abuse.
 	 */

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -78,14 +78,12 @@ class REST_Controller {
 	 * @return mixed            Returns Extended Access userState  object.
 	 */
 	public static function api_login_or_register_google_account( $request ) {
-		// Decode JWT.
-		$token = json_decode( base64_decode( str_replace( '_', '/', str_replace( '-', '+', explode( '.', $request->get_body() )[1] ) ) ) );
 
-		// Validate the token.
-		$token_api_id = $token->azp;
-		$google_client_api_id = get_option( 'newspack_extended_access__google_client_api_id', '' );
-		if ( $token_api_id !== $google_client_api_id ) {
-			return new \WP_Error( 'newspack_extended_access_google_token', __('Invalid token', 'newspack-extended-access'), array( 'status' => 403 ) );
+		// Decode JWT.
+		$google_token = new Google_Jwt( $request->get_body() );
+		$token        = $google_token->decode();
+		if ( is_wp_error( $token ) ) {
+			return $token;
 		}
 
 		// Get Google Email.


### PR DESCRIPTION
Tests the JWT token signature when performing checks.

Test the authentication flow using a Google account and confirm it works.

Make sure the cache is being refreshed when needed:

1. First perform a register/login to make sure a first version of the cache is created
2. Make sure the cache exists: `wp option get newspack_extended_access_google_jwk`
3. Edit the cached values and add invalid public keys. You can do this in WP SHELL:

```PHP
delete_option('newspack_extended_access_google_jwk_timestamp');
$x = get_option('newspack_extended_access_google_jwk');
$x['keys'][0]['n'] = 'ZZZZ6C6EeX8Dspje3FrAXw-nnhNk04e1RmNa4kjc0CHf6Pk7ryARlwA-6YilyPABqQfYHx60s8oSnxvUVprFfQ2-Q8aAZO7bPKSxnoGlcKERL2oLNA4Msvc89N9Y5ycThZUplf_QC19e6jyYXN6Nz-UnJSCLrtQY8tVhhVRs61j4A2N_p-enAi-r704Qi1-v-DKV4eVRkClKViploo8NyjUaT9L4vbBssPCjyimJzsWnEe1fED5c4LnHeArYzA_FEn3JJotqDIz9t2VnvZNTMhizHEX4VnORlEWMEfR8n4CEHQx7PcQUOmfqyw08gWeXQl1-uTjtIGaE-sRIv9ZZZZ';
$x['keys'][1]['n'] = 'ZZZZ6C6EeX8Dspje3FrAXw-nnhNk04e1RmNa4kjc0CHf6Pk7ryARlwA-6YilyPABqQfYHx60s8oSnxvUVprFfQ2-Q8aAZO7bPKSxnoGlcKERL2oLNA4Msvc89N9Y5ycThZUplf_QC19e6jyYXN6Nz-UnJSCLrtQY8tVhhVRs61j4A2N_p-enAi-r704Qi1-v-DKV4eVRkClKViploo8NyjUaT9L4vbBssPCjyimJzsWnEe1fED5c4LnHeArYzA_FEn3JJotqDIz9t2VnvZNTMhizHEX4VnORlEWMEfR8n4CEHQx7PcQUOmfqyw08gWeXQl1-uTjtIGaE-sRIv9ZZZZ';
update_option( 'newspack_extended_access_google_jwk', $x );
```

4. Try to perform a login adain and confirm it works
5. Check that the cache was refreshed and now have the correct values: `wp option get newspack_extended_access_google_jwk`