### PR TITLE
fix: catch the correct exception

### DIFF
--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -159,7 +159,7 @@ class Google_Jwt {
 			$jwks = $this->get_jwks();
 			try {
 				$decoded = Firebase_JWT::decode( $this->payload, Firebase_JWK::parseKeySet( $jwks ) );
-			} catch ( SignatureInvalidException $e ) {
+			} catch ( UnexpectedValueException $e ) {
 				return new \WP_Error( 'jwt_error', $e->getMessage() );
 			}
 		} catch ( UnexpectedValueException $e ) {


### PR DESCRIPTION
A small follow up for https://github.com/Automattic/newspack-extended-access/pull/5 

When we try to decode the token and we get an invalid key, we want to refresh googles's public keys and try again.

But then, when we try again, we need to catch all exceptions, and not only invalid tokens.

All exceptions thrown by the Firebase JWT lib extend `UnexpectedValueException`.

This avoids Fatal errors to be thrown in some scenarios