### PR TITLE
feat: Track User Registration Source for Google Extended Access

### DIFF
--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -116,6 +116,9 @@ class REST_Controller {
 			Newspack\Reader_Activation::set_current_reader( $user_id );
 			$existing_user = get_user_by( 'id', $user_id );
 
+			// For tracking registration source.
+			add_user_meta( $result, 'registered_by', 'google-extended-access' );
+
 			add_user_meta( $result, 'extended_access_sub', $token->sub );
 			remove_filter( 'newspack_reader_activation_enabled', '__return_true' );
 			// At this point the user will be logged in.

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -105,7 +105,7 @@ class REST_Controller {
 		} else {
 			// Enables registering through SWG even if it is disabled.
 			add_filter( 'newspack_reader_activation_enabled', '__return_true' );
-			$result = Newspack\Reader_Activation::register_reader( $email, '', true, array() );
+			$result = Newspack\Reader_Activation::register_reader( $email, '', true, [ 'registration_method' => 'google-extended-access' ] );
 
 			if ( is_numeric( $result ) ) {
 				$user_id = $result;
@@ -115,9 +115,6 @@ class REST_Controller {
 
 			Newspack\Reader_Activation::set_current_reader( $user_id );
 			$existing_user = get_user_by( 'id', $user_id );
-
-			// For tracking registration source.
-			add_user_meta( $result, 'registered_by', 'google-extended-access' );
 
 			add_user_meta( $result, 'extended_access_sub', $token->sub );
 			remove_filter( 'newspack_reader_activation_enabled', '__return_true' );


### PR DESCRIPTION
## Description

This pull request adds tracking for user registration source, specifically for users who register via Google Extended Access. 

### Key Changes:

- A new user meta field, `registered_by`, is added to users who successfully register using Google Extended Access.
- The `registered_by` field will store the value `google-extended-access` to identify these users.

Fixes: #7