### PR TITLE
Fix: Broken `my-account` Redirect

### DIFF
--- a/assets/js/newspack-swg.js
+++ b/assets/js/newspack-swg.js
@@ -99,7 +99,7 @@ function initGaaMetering() {
 					// Capture full URL, including URL parameters, to redirect the user to after login
 					const redirectUri = encodeURIComponent(window.location.href);
 					// Redirect to a login page for existing users to login.
-					window.location = `${window.location.protocol}//${window.location.hostname}/my-account?redirect_to=${redirectUri}`;
+					window.location = `${authenticationSettings.myAccountURL}?redirect_to=${redirectUri}`;
 				}
 			);
 		}

--- a/assets/js/newspack-swg.js
+++ b/assets/js/newspack-swg.js
@@ -99,7 +99,8 @@ function initGaaMetering() {
 					// Capture full URL, including URL parameters, to redirect the user to after login
 					const redirectUri = encodeURIComponent(window.location.href);
 					// Redirect to a login page for existing users to login.
-					window.location = `${authenticationSettings.myAccountURL}?redirect_to=${redirectUri}`;
+					// 'redirect' param is used by newspack plugin's reader-activation to prepare auth callback URL.
+					window.location = `${authenticationSettings.myAccountURL}?redirect=${redirectUri}`;
 				}
 			);
 		}

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -10,7 +10,7 @@ namespace Newspack\ExtendedAccess;
 
 use Newspack;
 
-define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0' );
+define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.1' );
 
 /**
  * Registers required scripts for SwG implementation

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -103,6 +103,7 @@ class Google_ExtendedAccess {
 					'allowedReferrers'  => $allowed_referrers,
 					'postID'            => get_the_ID(),
 					'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
+					'myAccountURL'      => wc_get_page_permalink( 'myaccount' )
 				)
 			);
 


### PR DESCRIPTION
### Issue:-
- When users attempt to switch Google accounts, they are redirected to the /my-account page. This is hard-coded and does not account for the fact that user's can change the my-accounts page from wc settings.
- The ?redirect_to parameter doesn't work as Newspack Plugin has a different parameter to prepare auth callback url.

https://github.com/Automattic/newspack-plugin/blob/fa051ff27cbc6339da4f0cda9093624436209946/includes/reader-activation/class-reader-activation.php#L1347

### Change:-

- Use the URL set by the user from the settings, pass it to frontend and utilise it to redirect user after login.
- Set the param used by newspack-plugin for preparing redirect.