### PR TITLE
fix: JWT Keyset cache invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,16 @@
     "wp-coding-standards/wpcs": "*",
     "dealerdirect/phpcodesniffer-composer-installer": "*",
     "phpcompatibility/phpcompatibility-wp": "*",
-    "yoast/phpunit-polyfills": "^1.0",
+    "yoast/phpunit-polyfills": "^1.1",
     "phpunit/phpunit": "^7.0 || ^9.5"
   },
   "autoload": {
     "classmap": [
       "./includes"
     ]
+  },
+  "scripts": {
+    "test": "phpunit"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e53dea6b75aca125558da3bd75c8552",
+    "content-hash": "bc8f84d567937a891601e65dc202d8e4",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -2271,16 +2271,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
                 "shasum": ""
             },
             "require": {
@@ -2288,12 +2288,14 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.3.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -2325,9 +2327,10 @@
             ],
             "support": {
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2025-01-08T16:58:34+00:00"
         }
     ],
     "aliases": [],
@@ -2337,5 +2340,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/unit-tests/test-google-jwt.php
+++ b/tests/unit-tests/test-google-jwt.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Tests the Settings.
+ *
+ * @package Newspack\Tests
+ */
+
+use Firebase\JWT\JWT;
+use Newspack\ExtendedAccess\Google_Jwt;
+
+require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
+
+/**
+ * Tests the Google JWT class methods.
+ */
+class Newspack_Test_Google_JWT extends WP_UnitTestCase {
+
+	/**
+	 * Setup for the tests.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Initialize .
+		\Newspack\ExtendedAccess\Google_ExtendedAccess::init();
+	}
+
+	/**
+	 * Test the decode() function to decode the JWT.
+	 * Case: valid JWT.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_valid_jwt(): void {
+		// Create a private key.
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 1024,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+
+		// Get the public key.
+		$public_key_details = openssl_pkey_get_details( $private_key );
+
+		// Generate a unique Key ID (kid).
+		$kid = 'test-key-id';
+
+		// Convert the RSA public key to a JWK format.
+		$jwk_key_set = $this->convert_rsa_to_jwk( $public_key_details, $kid );
+
+		// Update the options.
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'authorized-party' );
+
+		// Create a message.
+		$message = [
+			'iss' => 'http://google.org',
+			'aud' => 'http://google.com',
+			'iat' => 1356999524,
+			'nbf' => 1357000000,
+			'azp' => 'authorized-party',
+			'exp' => time() + 3600,
+		];
+
+		// Encode the message, including the correct "kid" in the header.
+		$jwt = JWT::encode(
+			$message,
+			$private_key,
+			'RS256',
+			$kid
+		);
+
+		// Create the Google_Jwt object.
+		$google_jwt = new Google_Jwt( $jwt );
+
+		// Test the decode function.
+		$result = $google_jwt->decode();
+
+		// Assert the result.
+		$this->assertNotWPError( $result );
+
+		// Assert the message.
+		$this->assertEquals( $message, (array) $result );
+	}
+
+	/**
+	 * Test the decode() function to decode the JWT.
+	 * Case: jwks is outdated.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_outdated_jwks(): void {
+		// Create a private key.
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 1024,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+
+		// Get the public key.
+		$public_key_details = openssl_pkey_get_details( $private_key );
+
+		// The Key stored in the cache is outdated and hence will be different from the one that will be in JWT.
+		$invalid_kid = 'invalid-key-id';
+		$valid_kid   = 'valid-key-id';
+
+		// Convert the RSA public key to a JWK format.
+		$valid_jwk_key_set   = $this->convert_rsa_to_jwk( $public_key_details, $valid_kid );
+		$invalid_jwk_key_set = $this->convert_rsa_to_jwk( $public_key_details, $invalid_kid );
+
+		// Update the options.
+		// Update the cache with the invalid JWK key set to simulate an outdated cache.
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $invalid_jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'authorized-party' );
+
+		// Create a message.
+		$message = [
+			'iss' => 'http://google.org',
+			'aud' => 'http://google.com',
+			'iat' => 1356999524,
+			'nbf' => 1357000000,
+			'azp' => 'authorized-party',
+			'exp' => time() + 3600,
+		];
+
+		// Encode the message, including the correct "kid" in the header.
+		$jwt = JWT::encode(
+			$message,
+			$private_key,
+			'RS256',
+			$valid_kid
+		);
+
+		// Create a mock for the Google_Jwt class to mock the get_jwks method.
+		$google_jwt_mock = $this->getMockBuilder( Google_Jwt::class )
+			->onlyMethods( ['get_jwks'] ) // Mock the get_jwks method
+			->setConstructorArgs( [ $jwt ] ) // Pass the JWT to the constructor
+			->getMock();
+
+		// Configure the mock to return the cached JWK key set when get_jwks is called.
+		// Because our code tries to refresh the jwks cache if the decode logic fails for the first time.
+		// So, we need to return the valid updated JWK key set fetched from Google.
+		$google_jwt_mock->method( 'get_jwks' )->willReturn( $valid_jwk_key_set ); // Return the cached JWK
+
+		// Test the decode function.
+		$result = $google_jwt_mock->decode();
+
+		// Assert the result.
+		$this->assertNotWPError( $result );
+
+		// Assert the message.
+		$this->assertEquals( $message, (array) $result );
+	}
+
+	/**
+	 * Test the function that checks if we should refresh the JWKS cache.
+	 * Case: The cache is outdated.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::should_refresh_jwks_cache
+	 *
+	 * @return void
+	 */
+	public function test_should_refresh_jwks_cache_outdated(): void {
+		// Update timestamp option.
+		update_option( Google_Jwt::CACHE_TIMESTAMP_OPTION_NAME, time() - 500 );
+
+		// Create the Google_Jwt object.
+		$google_jwt = new Google_Jwt( '' );
+
+		// Test the should_refresh_jwks_cache function.
+		$this->assertTrue( $google_jwt->should_refresh_jwks_cache() );
+	}
+
+	/**
+	 * Test the function that checks if we should refresh the JWKS cache.
+	 * Case: The cache is not outdated.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::should_refresh_jwks_cache
+	 *
+	 * @return void
+	 */
+	public function test_should_refresh_jwks_cache_not_outdated(): void {
+		// Create the Google_Jwt object.
+		$google_jwt = new Google_Jwt( '' );
+
+		// Update timestamp option.
+		update_option( Google_Jwt::CACHE_TIMESTAMP_OPTION_NAME, time() + 100 );
+
+		// Test the should_refresh_jwks_cache function.
+		$this->assertFalse( $google_jwt->should_refresh_jwks_cache() );
+	}
+
+	/**
+	 * Test the get_jwks_cached() function.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::get_jwks_cached
+	 *
+	 * @return void
+	 */
+	public function test_get_jwks_cached(): void {
+		// Create the Google_Jwt object.
+		$google_jwt = new Google_Jwt( '' );
+
+		// Update the options.
+		$jwk_key_set = [
+			'keys' => [
+				[
+					'kty' => 'RSA',
+					'kid' => 'test-key-id',
+					'n'   => 'test-n',
+					'e'   => 'test-e',
+					'alg' => 'RS256',
+					'use' => 'sig',
+				],
+			],
+		];
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+
+		// Test the get_jwks_cached function.
+		$result = $google_jwt->get_jwks_cached();
+
+		// Check the result.
+		$this->assertEquals( $jwk_key_set, $result );
+	}
+
+	/**
+	 * Test the update_jwks_cache() function.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::update_jwks_cache
+	 *
+	 * @return void
+	 */
+	public function test_update_jwks_cache(): void {
+		// Create the Google_Jwt object.
+		$google_jwt = new Google_Jwt( '' );
+
+		// Update the options.
+		$jwk_key_set = [
+			'keys' => [
+				[
+					'kty' => 'RSA',
+					'kid' => 'test-key-id',
+					'n'   => 'test-n',
+					'e'   => 'test-e',
+					'alg' => 'RS256',
+					'use' => 'sig',
+				],
+			],
+		];
+		$google_jwt->update_jwks_cache( $jwk_key_set );
+
+		// Test the get_jwks_cached function.
+		$result = get_option( Google_Jwt::CACHE_OPTION_NAME );
+
+		// Check the result.
+		$this->assertEquals( $jwk_key_set, $result );
+	}
+
+	/**
+	 * Converts an RSA public key to a JWK format with a "kid".
+	 *
+	 * @param array  $key_details The RSA public key details.
+	 * @param string $kid         The Key ID.
+	 * @return array The JWK key set.
+	 */
+	private function convert_rsa_to_jwk( $key_details, $kid ): array {
+		// Encode the RSA public key.
+		$n = base64_encode( $key_details['rsa']['n'] );
+		$e = base64_encode( $key_details['rsa']['e'] );
+
+		return [
+			'keys' => [
+				[
+					'kty' => 'RSA',
+					'kid' => $kid,
+					'n'   => str_replace( [ '+', '/', '=' ], [ '-', '_', '' ], $n ),
+					'e'   => str_replace( [ '+', '/', '=' ], [ '-', '_', '' ], $e ),
+					'alg' => 'RS256',
+					'use' => 'sig',
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
### Issue:-
- The JWT keyset retrieval logic first gets the keyset from the cache and checks if it needs to invalidate it and fetch new keyset.
- The cached keyset stored in the options table is never invalidated, even when it's stale. This leads to the invalid kid (key ID) error when decoding JWT tokens.

https://github.com/Automattic/newspack-extended-access/blob/6737b49132cb2f37d46bcf485742121f843bc58b/includes/class-google-jwt.php#L147-L150

### Proposed Changes:-

- Refactor the code to fetch the JWT keyset after trying once with the cached key set.
- Handle the exception if it fails again.