### PR TITLE
fix: Handle if www is part of host

### DIFF
--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -46,7 +46,7 @@ class Google_ExtendedAccess {
 			$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
 			$url_parts = wp_parse_url( home_url() );
-			$domain    = $url_parts['host'];
+			$domain    = str_replace( 'www.', '', $url_parts['host'] );
 
 			$ld_json = array(
 				'@context'            => 'https://schema.org',


### PR DESCRIPTION
Fixes the scenario where a site has `www` as part of its host name, for example `www.example.com`. If a site has `www` in the host, it will make requests to `https://news.google.com/swg/_/api/v1/publication/www.example.com/article`, and these requests will return 404 response, since Google News wants publishers to omit the `www` from their publication.

I don't have a great way of testing this, but confirm the logic is solid and won't cause problems.