### PR TITLE
Reduce number of API calls

### DIFF
--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -84,6 +84,12 @@ class Google_ExtendedAccess {
 			return;
 
 		}
+
+		// Only enqueue scripts when Extended Access is happening.
+                if ( empty( $_GET['gaa_ts'] ) ) {
+                        return;
+                }
+		
 		// Add scripts only for `post` type.
 		if ( get_post_type() === 'post' ) { // Add slug in condition.
 			// Newspack Extended Access Script.

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -19,11 +19,19 @@ define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.1' );
 class Google_ExtendedAccess {
 
 	/**
+	 * Google Extended Access URL parameter.
+	 *
+	 * @var string
+	 */
+	const GOOGLE_EA_REQUEST_PARAM = 'gaa_ts';
+
+	/**
 	 * Set up hooks and filters.
 	 */
 	public static function init() {
 		add_action( 'wp_head', array( __CLASS__, 'add_extended_access_ld_json' ), -1 );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_script' ) );
+		add_action( 'query_vars', array( __CLASS__, 'add_extended_access_query_vars' ) );
 	}
 
 	/**
@@ -77,19 +85,29 @@ class Google_ExtendedAccess {
 	}
 
 	/**
+	 * Add query vars for Google Extended Access.
+	 *
+	 * @param array $vars Query vars.
+	 * @return array
+	 */
+	public static function add_extended_access_query_vars( $vars ) {
+		$vars[] = self::GOOGLE_EA_REQUEST_PARAM;
+		return $vars;
+	}
+
+	/**
 	 * Enqueues scripts for Google Extended Access and Newspack SWG script.
 	 */
 	public static function enqueue_script() {
 		if ( ! self::can_insert_frontend_markup() ) {
 			return;
-
 		}
 
 		// Only enqueue scripts when Extended Access is happening.
-                if ( empty( $_GET['gaa_ts'] ) ) {
-                        return;
-                }
-		
+		if ( empty( get_query_var( self::GOOGLE_EA_REQUEST_PARAM ) ) ) {
+			return;
+		}
+
 		// Add scripts only for `post` type.
 		if ( get_post_type() === 'post' ) { // Add slug in condition.
 			// Newspack Extended Access Script.


### PR DESCRIPTION
The API call to `/wp-json/newspack-extended-access/v1/login/status` happens on every single pageload, but I think we really only need it on pageloads from Google News for extended access.

To test:
1. Visit a page like https://extended-access-dev.newspackstaging.com/2023/03/16/non-quisque-consequat-lobortis-aptent-dictum-maximus-sem-auctor-tempus/?gaa_at=testa&gaa_n=112&gaa_sig=1s&gaa_ts=999999999 and confirm the API call fires.
2. Visit a page like https://extended-access-dev.newspackstaging.com/2023/03/16/non-quisque-consequat-lobortis-aptent-dictum-maximus-sem-auctor-tempus/ and confirm API call does not fire.