### PR TITLE
feat: enhance `NewsArticle` schema with additional metadata

### DIFF
--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -58,8 +58,12 @@ class Google_ExtendedAccess {
 
 			$ld_json = array(
 				'@context'            => 'https://schema.org',
-				'@type'               => 'Article',
+				'@type'               => 'NewsArticle',
+				'headline'            => get_the_title(),
 				'isAccessibleForFree' => ! wc_memberships_is_post_content_restricted(),
+				'inLanguage'          => get_bloginfo( 'language' ),
+				'url'                 => get_permalink(),
+				'description'         => get_the_excerpt(),
 				'isPartOf'            => array(
 					'@type'     => array( 'CreativeWork', 'Product' ),
 					'name'      => get_bloginfo( 'name' ),
@@ -68,8 +72,61 @@ class Google_ExtendedAccess {
 				'publisher'           => array(
 					'@type' => 'Organization',
 					'name'  => get_bloginfo( 'name' ),
+					'url'   => home_url(),
+					'logo'  => [
+						'@type'  => 'ImageObject',
+						'url'    => get_site_icon_url(),
+					],
 				),
 			);
+
+			// Dates in ISO 8601 format as per schema standards.
+			$ld_json['datePublished'] = get_the_date( 'c' );
+			$ld_json['dateModified']  = get_the_modified_date( 'c' );
+
+			$post_authors      = [];
+			$ld_json['author'] = [ // Default to the organization.
+				'@type' => 'Organization',
+				'name'  => get_bloginfo( 'name' ),
+				'url'   => home_url(),
+			];
+			if ( function_exists( 'get_coauthors' ) ) {
+				$post_authors = get_coauthors();
+			}
+			if ( empty( $post_authors ) ) {
+				$author_id    = absint( get_the_author_meta( 'ID' ) );
+				$post_authors = array( get_userdata( $author_id ) );
+			}
+			if ( ! empty( $post_authors ) ) {
+				$authors = array();
+				foreach ( $post_authors as $author ) {
+					if ( $author ) {
+						$author_data = [
+							'@type' => 'Person',
+							'name'  => $author->display_name,
+						];
+
+						$author_url = get_author_posts_url( $author->ID );
+						if ( $author_url ) {
+							$author_data['url'] = $author_url;
+						}
+
+						$authors[] = $author_data;
+					}
+				}
+
+				if ( ! empty( $authors ) ) {
+					$ld_json['author'] = count( $authors ) === 1 ? $authors[0] : $authors;
+				}
+			}
+
+			if ( has_post_thumbnail() ) {
+				$image_url = get_the_post_thumbnail_url();
+				if ( $image_url ) {
+					$ld_json['thumbnailUrl'] = $image_url;
+					$ld_json['image']        = $image_url; // This could be any image or array of images, not just the thumbnail.
+				}
+			}
 
 			$ld_json = wp_json_encode( $ld_json, $flags );
 			$ld_json = str_replace( "\n", PHP_EOL . "\t", $ld_json );

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -123,7 +123,11 @@ class Google_ExtendedAccess {
 			if ( has_post_thumbnail() ) {
 				$image_url               = get_the_post_thumbnail_url();
 				$ld_json['thumbnailUrl'] = $image_url;
-				$ld_json['image']        = $image_url; // This could be any image or array of images, not just the thumbnail.
+				/**
+				 * This could be an array with different image sizes.
+				 * See: https://developers.google.com/search/docs/appearance/structured-data/article
+				 */
+				$ld_json['image'] = $image_url;
 			}
 
 			$ld_json = wp_json_encode( $ld_json, $flags );

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -121,11 +121,9 @@ class Google_ExtendedAccess {
 			}
 
 			if ( has_post_thumbnail() ) {
-				$image_url = get_the_post_thumbnail_url();
-				if ( $image_url ) {
-					$ld_json['thumbnailUrl'] = $image_url;
-					$ld_json['image']        = $image_url; // This could be any image or array of images, not just the thumbnail.
-				}
+				$image_url               = get_the_post_thumbnail_url();
+				$ld_json['thumbnailUrl'] = $image_url;
+				$ld_json['image']        = $image_url; // This could be any image or array of images, not just the thumbnail.
 			}
 
 			$ld_json = wp_json_encode( $ld_json, $flags );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Closes: https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210734649382285?focus=true

This PR updates the structured data output to use the more appropriate NewsArticle schema type instead of the generic Article. It also adds key fields recommended by Google for rich results while switching @type from generic `Article` to `NewsArticle`. Including other meta data including publishing/modifying dates, authors, images metadata.

### How to test the changes:-

1. Open any post and copy page source.
2. Open google rich text testing tool.
3. Paste the code or directly paste the URL if testing on a hosted site.
4. Check the results, and verify the results and fields appearing as expected.

### Sample result:-
Test post:- [Non quisque consequat lobortis aptent dictum maximus sem auctor tempus](https://extended-access-dev.newspackstaging.com/2023/03/16/non-quisque-consequat-lobortis-aptent-dictum-maximus-sem-auctor-tempus/)

Result:- https://search.google.com/test/rich-results/result?id=fglnGYfxWr45o8U4wLKp8A