### PR TITLE
Adjustments & fixes to logic and flow

### DIFF
--- a/assets/js/newspack-swg.js
+++ b/assets/js/newspack-swg.js
@@ -42,6 +42,13 @@ function initGaaMetering() {
 	const allowedReferrers = authenticationSettings.allowedReferrers;
 
 	/**
+	 * Base URL for this plugin's REST namespace, localized from `rest_url()` so
+	 * it carries the site's port, subdirectory and permalink structure. Always
+	 * ends with a slash.
+	 */
+	const restURL = authenticationSettings.restURL;
+
+	/**
 	 * Login Existing User Promise callback handler.
 	 */
 	handleLoginPromise = new Promise(
@@ -70,7 +77,7 @@ function initGaaMetering() {
 					// return the userState for the newly registered user.
 
 					fetch(
-						`${window.location.protocol}//${window.location.hostname}/wp-json/newspack-extended-access/v1/google/register`,
+						`${restURL}google/register`,
 						{
 							cache: 'no-store',
 							method: 'POST',
@@ -122,7 +129,7 @@ function initGaaMetering() {
 	getUserState = new Promise(
 		(resolve) => {
 			fetch(
-				`${window.location.protocol}//${window.location.hostname}/wp-json/newspack-extended-access/v1/login/status`,
+				`${restURL}login/status`,
 				{
 					cache: 'no-store',
 					method: 'GET',
@@ -151,7 +158,7 @@ function initGaaMetering() {
 	 */
 	unlockArticle = () => {
 		fetch(
-			`${window.location.protocol}//${window.location.hostname}/wp-json/newspack-extended-access/v1/unlock-article`,
+			`${restURL}unlock-article`,
 			{
 				cache: 'no-store',
 				method: 'POST',

--- a/assets/js/newspack-swg.js
+++ b/assets/js/newspack-swg.js
@@ -143,21 +143,13 @@ function initGaaMetering() {
 	);
 
 	/**
-	 * Fires when Extended Access grants permission.
+	 * Fires when Google grants Extended Access — i.e. when the reader dismisses
+	 * the Extended Access CTA. We must record that grant server-side by hitting
+	 * /unlock-article (which sets a per-(user, post) cookie that
+	 * SinglePost_Subscription reads to lift the WC Memberships restriction),
+	 * then reload so the unrestricted page renders.
 	 */
 	unlockArticle = () => {
-		if (window.localStorage) {
-			if (!localStorage.getItem('unlocked')) {
-				localStorage['unlocked'] = true;
-				window.location.reload();
-			}
-		}
-	}
-
-	/**
-	 * Display custom paywall instead of Google Intervention Dialog.
-	 */
-	showPaywall = () => {
 		fetch(
 			`${window.location.protocol}//${window.location.hostname}/wp-json/newspack-extended-access/v1/unlock-article`,
 			{
@@ -172,15 +164,25 @@ function initGaaMetering() {
 		)
 			.then(response => response.json())
 			.then(jsonData => {
-				if (jsonData.status === 'UNLOCKED') {
-					if (window.localStorage) {
-						if (localStorage.getItem('unlocked') && localStorage['unlocked'] === "true") {
-							localStorage.removeItem('unlocked');
-						}
-					}
+				// Reload for either response shape: UNLOCKED (metered grant
+				// recorded) or SUBSCRIBER (the user already has membership
+				// access, no cookie needed but a reload still ensures the EA
+				// CTA disappears on the next render).
+				if (jsonData.status === 'UNLOCKED' || jsonData.status === 'SUBSCRIBER') {
 					window.location.reload();
 				}
 			});
+	}
+
+	/**
+	 * Fires when Google declines Extended Access, or when the reader clicks
+	 * Subscribe on the EA CTA. In either case the WC Memberships paywall is
+	 * already rendered on the page (server-side) and exposes the publisher's
+	 * subscribe button, so this callback is intentionally a no-op — we do not
+	 * want to unlock the article here.
+	 */
+	showPaywall = () => {
+		// Intentionally empty. See JSDoc.
 	}
 
 	/**

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -36,9 +36,15 @@ class Google_ExtendedAccess {
 
 	/**
 	 * Check conditions for frontend markup insertion.
+	 *
+	 * Extended Access targets article pages, so both the LD+JSON schema
+	 * (which declares `@type: Article`) and the SwG client libraries are
+	 * scoped to single post views. Without this gate the schema would leak
+	 * onto archives, pages, search, and CPT singulars where the `Article`
+	 * type is incorrect and would confuse Google.
 	 */
 	private static function can_insert_frontend_markup() {
-		return ! is_front_page() && ! is_404();
+		return is_singular( 'post' );
 	}
 
 	/**
@@ -108,56 +114,53 @@ class Google_ExtendedAccess {
 			return;
 		}
 
-		// Add scripts only for `post` type.
-		if ( get_post_type() === 'post' ) { // Add slug in condition.
-			// Newspack Extended Access Script.
-			$assets_path = plugins_url( '../assets/', __FILE__ );
-			wp_register_script( 'newspack-swg', $assets_path . 'js/newspack-swg.js', array(), NEWSPACK_SWG_SCRIPT_VERSION, array( 'strategy' => 'async' ) );
-			wp_enqueue_script( 'newspack-swg' );
+		// Newspack Extended Access Script.
+		$assets_path = plugins_url( '../assets/', __FILE__ );
+		wp_register_script( 'newspack-swg', $assets_path . 'js/newspack-swg.js', array(), NEWSPACK_SWG_SCRIPT_VERSION, array( 'strategy' => 'async' ) );
+		wp_enqueue_script( 'newspack-swg' );
 
-			$home_url_parts    = wp_parse_url( home_url() );
-			$allowed_referrers = array( $home_url_parts['host'] );
+		$home_url_parts    = wp_parse_url( home_url() );
+		$allowed_referrers = array( $home_url_parts['host'] );
 
-			// Nonce for REST API.
-			wp_localize_script(
-				'newspack-swg',
-				'authenticationSettings',
-				array(
-					'nonce'             => wp_create_nonce( 'wp_rest' ),
-					'allowedReferrers'  => $allowed_referrers,
-					'postID'            => get_the_ID(),
-					'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
-					'myAccountURL'      => wc_get_page_permalink( 'myaccount' )
-				)
-			);
+		// Nonce for REST API.
+		wp_localize_script(
+			'newspack-swg',
+			'authenticationSettings',
+			array(
+				'nonce'             => wp_create_nonce( 'wp_rest' ),
+				'allowedReferrers'  => $allowed_referrers,
+				'postID'            => get_the_ID(),
+				'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
+				'myAccountURL'      => wc_get_page_permalink( 'myaccount' ),
+			)
+		);
 
-			// Google Extended Access Scripts.
-			wp_print_script_tag(
-				array(
-					'id'    => 'google-account-gsi-client',
-					'async' => true,
-					'src'   => esc_url( 'https://accounts.google.com/gsi/client' ),
-					'defer' => true,
-				)
-			);
+		// Google Extended Access Scripts.
+		wp_print_script_tag(
+			array(
+				'id'    => 'google-account-gsi-client',
+				'async' => true,
+				'src'   => esc_url( 'https://accounts.google.com/gsi/client' ),
+				'defer' => true,
+			)
+		);
 
-			wp_print_script_tag(
-				array(
-					'id'                    => 'google-news-swg',
-					'async'                 => true,
-					'subscriptions-control' => 'manual',
-					'src'                   => esc_url( 'https://news.google.com/swg/js/v1/swg.js' ),
-				)
-			);
+		wp_print_script_tag(
+			array(
+				'id'                    => 'google-news-swg',
+				'async'                 => true,
+				'subscriptions-control' => 'manual',
+				'src'                   => esc_url( 'https://news.google.com/swg/js/v1/swg.js' ),
+			)
+		);
 
-			wp_print_script_tag(
-				array(
-					'id'     => 'google-news-swg-gaa',
-					'defer'  => true,
-					'src'    => esc_url( 'https://news.google.com/swg/js/v1/swg-gaa.js' ),
-					'onload' => 'initGaaMetering()',
-				)
-			);
-		}
+		wp_print_script_tag(
+			array(
+				'id'     => 'google-news-swg-gaa',
+				'defer'  => true,
+				'src'    => esc_url( 'https://news.google.com/swg/js/v1/swg-gaa.js' ),
+				'onload' => 'initGaaMetering()',
+			)
+		);
 	}
 }

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -10,7 +10,7 @@ namespace Newspack\ExtendedAccess;
 
 use Newspack;
 
-define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.1' );
+define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.2' );
 
 /**
  * Registers required scripts for SwG implementation

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -10,7 +10,7 @@ namespace Newspack\ExtendedAccess;
 
 use Newspack;
 
-define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.2' );
+define( 'NEWSPACK_SWG_SCRIPT_VERSION', '1.0.3' );
 
 /**
  * Registers required scripts for SwG implementation
@@ -132,6 +132,10 @@ class Google_ExtendedAccess {
 				'postID'            => get_the_ID(),
 				'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
 				'myAccountURL'      => wc_get_page_permalink( 'myaccount' ),
+				// Built with `rest_url()` so the script works on installs served
+				// from a subdirectory, a non-standard port, or with plain
+				// permalinks (where REST lives under `?rest_route=`).
+				'restURL'           => esc_url_raw( rest_url( REST_Controller::NAMESPACE . '/' ) ),
 			)
 		);
 

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -179,8 +179,11 @@ class Google_Jwt {
 		// Validate the token's audience. `aud` must match our Google Client API ID.
 		// `azp` (authorized party) is not a substitute: it's optional and may be absent,
 		// and a token issued for a different app could still carry the expected `azp`.
+		// Per RFC 7519 `aud` is either a single string or an array of strings, so
+		// accept both shapes.
 		$google_client_api_id = get_option( 'newspack_extended_access__google_client_api_id', '' );
-		if ( ! isset( $decoded->aud ) || $decoded->aud !== $google_client_api_id ) {
+		$token_audiences      = isset( $decoded->aud ) ? (array) $decoded->aud : array();
+		if ( '' === $google_client_api_id || ! in_array( $google_client_api_id, $token_audiences, true ) ) {
 			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token audience.', 'newspack-extended-access' ), array( 'status' => 403 ) );
 		}
 

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -169,11 +169,19 @@ class Google_Jwt {
 			}
 		}
 
-		// Validate the token.
-		$token_api_id         = $decoded->azp;
+		// Validate the token's issuer. Per Google's ID token verification guidance,
+		// `iss` must be either `accounts.google.com` or `https://accounts.google.com`.
+		$valid_issuers = array( 'https://accounts.google.com', 'accounts.google.com' );
+		if ( ! isset( $decoded->iss ) || ! in_array( $decoded->iss, $valid_issuers, true ) ) {
+			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token issuer.', 'newspack-extended-access' ), array( 'status' => 403 ) );
+		}
+
+		// Validate the token's audience. `aud` must match our Google Client API ID.
+		// `azp` (authorized party) is not a substitute: it's optional and may be absent,
+		// and a token issued for a different app could still carry the expected `azp`.
 		$google_client_api_id = get_option( 'newspack_extended_access__google_client_api_id', '' );
-		if ( $token_api_id !== $google_client_api_id ) {
-			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token', 'newspack-extended-access' ), array( 'status' => 403 ) );
+		if ( ! isset( $decoded->aud ) || $decoded->aud !== $google_client_api_id ) {
+			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token audience.', 'newspack-extended-access' ), array( 'status' => 403 ) );
 		}
 
 		return $decoded;

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -48,6 +48,23 @@ class REST_Controller {
 	}
 
 	/**
+	 * Derive an opaque, stable userState `id` for a reader who has no Google
+	 * `sub` (i.e. registered through a channel other than Extended Access).
+	 *
+	 * Keyed with `wp_hash()` so the value is stable for a given user on a given
+	 * site but cannot be decoded back to the internal WordPress user ID. It is
+	 * tied to the site's auth salts, so rotating them re-issues the id and
+	 * Google sees the reader as new — an acceptable trade for not leaking an
+	 * enumerable user ID.
+	 *
+	 * @param int $user_id The user ID.
+	 * @return string Opaque identifier.
+	 */
+	private static function get_derived_user_state_id( $user_id ) {
+		return 'wp_' . wp_hash( 'newspack_extended_access_user_state|' . $user_id );
+	}
+
+	/**
 	 * Resolve the `subscriptionTimestamp` for the userState payload.
 	 *
 	 * Per the Extended Access spec this should reflect when the user became a
@@ -159,9 +176,11 @@ class REST_Controller {
 		$email = $token->email;
 
 		$existing_user = get_user_by( 'email', $email );
-		$post_id       = $request->get_header( 'X-WP-Post-ID' );
-		$user_id       = false;
-		$granted       = false;
+		// Normalise to an int so the unlock cookie name hashes identically
+		// everywhere it is written and read.
+		$post_id = absint( $request->get_header( 'X-WP-Post-ID' ) );
+		$user_id = false;
+		$granted = false;
 
 		if ( $existing_user ) {
 			$user_id = $existing_user->ID;
@@ -282,7 +301,11 @@ class REST_Controller {
 	 */
 	public static function api_verify_user( $request ) {
 		$logged_in_user = wp_get_current_user();
-		$post_id        = $request->get_header( 'X-WP-Post-ID' );
+		// Normalise to an int so the unlock cookie name hashes identically to the
+		// one `api_unlock_article()` sets — a non-canonical numeric header (e.g.
+		// "042") would otherwise produce a different hash and metering would
+		// never be detected.
+		$post_id = absint( $request->get_header( 'X-WP-Post-ID' ) );
 
 		// Anonymous visitor — Google should show the registration intervention.
 		if ( ! $logged_in_user || ! $logged_in_user->ID ) {
@@ -313,9 +336,11 @@ class REST_Controller {
 		// registered via Extended Access (so Google can correlate identities
 		// across visits); otherwise derive a stable id from the WP user ID so
 		// users who registered through other channels are still recognised as
-		// "registered users" instead of being treated as anonymous.
+		// "registered users" instead of being treated as anonymous. The derived
+		// id is a keyed hash rather than an encoding, so the internal user ID
+		// can't be recovered from the value we hand to Google.
 		$jwt_sub       = get_user_meta( $user_id, 'extended_access_sub', true );
-		$user_state_id = $jwt_sub ? base64_encode( $jwt_sub ) : base64_encode( 'wp_' . $user_id );
+		$user_state_id = $jwt_sub ? base64_encode( $jwt_sub ) : self::get_derived_user_state_id( $user_id );
 
 		// Subscriber: publisher membership grants access to the requested post.
 		$member_can_view_post = false;

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -48,6 +48,42 @@ class REST_Controller {
 	}
 
 	/**
+	 * Resolve the `subscriptionTimestamp` for the userState payload.
+	 *
+	 * Per the Extended Access spec this should reflect when the user became a
+	 * subscriber, not when their WP account was created. We use the earliest
+	 * start date across the user's active WC Memberships; if none can be
+	 * resolved we fall back to the supplied registration timestamp so the
+	 * response shape is still spec-compliant.
+	 *
+	 * @param int $user_id              The user ID.
+	 * @param int $fallback_timestamp   Timestamp to return when no membership can be resolved.
+	 * @return int Unix timestamp.
+	 */
+	private static function get_subscription_timestamp( $user_id, $fallback_timestamp ) {
+		if ( ! function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
+			return $fallback_timestamp;
+		}
+
+		$memberships = wc_memberships_get_user_active_memberships( $user_id );
+		if ( empty( $memberships ) ) {
+			return $fallback_timestamp;
+		}
+
+		$earliest = null;
+		foreach ( $memberships as $membership ) {
+			$start = is_object( $membership ) && method_exists( $membership, 'get_start_date' )
+				? (int) $membership->get_start_date( 'timestamp' )
+				: 0;
+			if ( $start > 0 && ( null === $earliest || $start < $earliest ) ) {
+				$earliest = $start;
+			}
+		}
+
+		return null === $earliest ? $fallback_timestamp : $earliest;
+	}
+
+	/**
 	 * Registers REST Endpoints for Extended Access.
 	 */
 	public static function register_api_endpoints() {
@@ -148,13 +184,14 @@ class REST_Controller {
 		}
 
 		if ( $member_can_view_post ) {
-			$response = rest_ensure_response(
+			$registration_timestamp = strtotime( $existing_user->user_registered );
+			$response               = rest_ensure_response(
 				array(
 					'id'                    => base64_encode( $token->sub ),
 					'email'                 => $email,
 					'postId'                => $post_id,
-					'registrationTimestamp' => strtotime( $existing_user->user_registered ),
-					'subscriptionTimestamp' => strtotime( $existing_user->user_registered ), // TODO (@AnuragVasanwala): This should be revised.
+					'registrationTimestamp' => $registration_timestamp,
+					'subscriptionTimestamp' => self::get_subscription_timestamp( $user_id, $registration_timestamp ),
 					'granted'               => true,
 					'grantReason'           => 'SUBSCRIBER',
 				)
@@ -279,7 +316,7 @@ class REST_Controller {
 					'id'                    => $user_state_id,
 					'email'                 => $email,
 					'registrationTimestamp' => $registration_timestamp,
-					'subscriptionTimestamp' => $registration_timestamp, // TODO (@AnuragVasanwala): This should be revised.
+					'subscriptionTimestamp' => self::get_subscription_timestamp( $user_id, $registration_timestamp ),
 					'granted'               => true,
 					'grantReason'           => 'SUBSCRIBER',
 				)

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -235,103 +235,87 @@ class REST_Controller {
 		$logged_in_user = wp_get_current_user();
 		$post_id        = $request->get_header( 'X-WP-Post-ID' );
 
-		if ( $logged_in_user ) {
-			$email         = $logged_in_user->user_email;
-			$existing_user = get_user_by( 'email', $email );
+		// Anonymous visitor — Google should show the registration intervention.
+		if ( ! $logged_in_user || ! $logged_in_user->ID ) {
+			$response = rest_ensure_response( array( 'granted' => false ) );
+			$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
+			return $response;
+		}
 
-			if ( $existing_user ) {
-				// Log the user in.
-				$result = Newspack\Reader_Activation::set_current_reader( $existing_user->ID );
+		$user_id                = $logged_in_user->ID;
+		$email                  = $logged_in_user->user_email;
+		$registration_timestamp = strtotime( $logged_in_user->user_registered );
 
-				if ( is_wp_error( $result ) ) {
-					$response = rest_ensure_response(
-						array(
-							'granted' => false,
-							'reason'  => $result,
-						)
-					);
-					$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-					return $response;
-				}
-
-				$granted = false;
-				$user_id = $logged_in_user->ID;
-				$jwt_sub = get_user_meta( $user_id, 'extended_access_sub', true );
-
-				// Checks if cookie is set, grants access only if cookie is set.
-				if ( $jwt_sub ) {
-					$member_can_view_post = false;
-					if ( function_exists( 'wc_memberships_user_can' ) ) {
-						$member_can_view_post = wc_memberships_user_can( $existing_user->ID, 'view', array( 'post' => $post_id ) );
-					}
-
-					$cookie_name = self::get_unlock_cookie_name( $post_id, $user_id );
-
-					if ( $member_can_view_post ) {
-						$response = rest_ensure_response(
-							array(
-								'id'                    => base64_encode( $jwt_sub ),
-								'email'                 => $email,
-								'registrationTimestamp' => strtotime( $logged_in_user->user_registered ),
-								'subscriptionTimestamp' => strtotime( $logged_in_user->user_registered ), // TODO (@AnuragVasanwala): This should be revised.
-								'granted'               => true,
-								'grantReason'           => 'SUBSCRIBER',
-							)
-						);
-						$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-						return $response;
-					} elseif ( isset( $_COOKIE[ $cookie_name ] ) ) {
-						$response = rest_ensure_response(
-							array(
-								'id'                    => base64_encode( $jwt_sub ),
-								'email'                 => $email,
-								'registrationTimestamp' => strtotime( $logged_in_user->user_registered ),
-								'granted'               => true,
-								'grantReason'           => 'METERING',
-							)
-						);
-						$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-						return $response;
-					} else {
-						$response = rest_ensure_response(
-							array(
-								'id'                    => base64_encode( $jwt_sub ),
-								'email'                 => $email,
-								'registrationTimestamp' => strtotime( $logged_in_user->user_registered ),
-								'granted'               => false,
-							)
-						);
-						$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-						return $response;
-					}
-				} else {
-					$response = rest_ensure_response(
-						array(
-							'granted' => false,
-						)
-					);
-					$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-					return $response;
-				}
-			} else {
-				$response = rest_ensure_response(
-					array(
-						'granted' => false,
-						'reason'  => 'USER_DOES_NOT_EXISTS',
-					)
-				);
-				$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
-				return $response;
-			}
-		} else {
+		// Refresh the current reader so the Newspack reader activation system
+		// keeps in sync with the logged-in user.
+		$result = Newspack\Reader_Activation::set_current_reader( $user_id );
+		if ( is_wp_error( $result ) ) {
 			$response = rest_ensure_response(
 				array(
 					'granted' => false,
-					'reason'  => 'NO_LOGGEND_IN_USER',
+					'reason'  => $result->get_error_code(),
 				)
 			);
 			$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
 			return $response;
 		}
+
+		// Build the userState `id`. Prefer the Google `sub` when the user
+		// registered via Extended Access (so Google can correlate identities
+		// across visits); otherwise derive a stable id from the WP user ID so
+		// users who registered through other channels are still recognised as
+		// "registered users" instead of being treated as anonymous.
+		$jwt_sub       = get_user_meta( $user_id, 'extended_access_sub', true );
+		$user_state_id = $jwt_sub ? base64_encode( $jwt_sub ) : base64_encode( 'wp_' . $user_id );
+
+		// Subscriber: publisher membership grants access to the requested post.
+		$member_can_view_post = false;
+		if ( $post_id && function_exists( 'wc_memberships_user_can' ) ) {
+			$member_can_view_post = wc_memberships_user_can( $user_id, 'view', array( 'post' => $post_id ) );
+		}
+		if ( $member_can_view_post ) {
+			$response = rest_ensure_response(
+				array(
+					'id'                    => $user_state_id,
+					'email'                 => $email,
+					'registrationTimestamp' => $registration_timestamp,
+					'subscriptionTimestamp' => $registration_timestamp, // TODO (@AnuragVasanwala): This should be revised.
+					'granted'               => true,
+					'grantReason'           => 'SUBSCRIBER',
+				)
+			);
+			$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
+			return $response;
+		}
+
+		// Metered: a previously granted unlock cookie is present for this post.
+		$cookie_name = self::get_unlock_cookie_name( $post_id, $user_id );
+		if ( $post_id && isset( $_COOKIE[ $cookie_name ] ) ) {
+			$response = rest_ensure_response(
+				array(
+					'id'                    => $user_state_id,
+					'email'                 => $email,
+					'registrationTimestamp' => $registration_timestamp,
+					'granted'               => true,
+					'grantReason'           => 'METERING',
+				)
+			);
+			$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
+			return $response;
+		}
+
+		// Registered user with no current grant. `id` and `registrationTimestamp`
+		// signal to Google that this is a known reader so it can evaluate Extended
+		// Access (showing the EA CTA) instead of the registration intervention.
+		$response = rest_ensure_response(
+			array(
+				'id'                    => $user_state_id,
+				'email'                 => $email,
+				'registrationTimestamp' => $registration_timestamp,
+				'granted'               => false,
+			)
+		);
+		$response->set_headers( array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ) );
+		return $response;
 	}
 }

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -103,12 +103,24 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'api_unlock_article' ),
+				/*
+				 * Any logged-in reader may unlock an article. In a *client-side*
+				 * Extended Access paywall (the mode this plugin operates in),
+				 * Google's GAA library performs all grant-policy evaluation in
+				 * the browser and calls `unlockArticle` only when it decides
+				 * to grant access — the publisher's job is just to honor that
+				 * decision. The endpoint is therefore protected by WP auth +
+				 * the REST nonce, and the resulting unlock cookie is keyed to
+				 * the (post, user) pair so a grant can't be replayed for
+				 * another reader. We previously gated this on the
+				 * `extended_access_sub` user-meta, but that excluded readers
+				 * who reached the article via the "Already registered? Sign
+				 * in" branch (Use Case 4) — Google grants them EA but they
+				 * never went through the Google-registration code path and
+				 * therefore have no `extended_access_sub` set.
+				 */
 				'permission_callback' => function () {
-					if ( ! is_user_logged_in() ) {
-						return false;
-					}
-					// Only Extended Access users (registered via Google) may unlock articles.
-					return (bool) get_user_meta( get_current_user_id(), 'extended_access_sub', true );
+					return is_user_logged_in();
 				},
 			)
 		);

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -416,18 +416,25 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures logged-in user without Extended Access registration cannot unlock articles.
+	 * A logged-in reader who never registered via Google Extended Access — for
+	 * example a pre-existing publisher reader who reached the article via the
+	 * "Already registered? Sign in" branch of Use Case 4 — must still be able
+	 * to unlock the article when Google's GAA library decides to grant them
+	 * EA. Previously the endpoint gated on `extended_access_sub` user-meta
+	 * and 403'd these users, which broke the dismiss-CTA → unlock flow for
+	 * any reader whose account predated EA.
 	 */
-	public function test_unlock_article__non_extended_access_user() {
+	public function test_unlock_article__logged_in_user_without_ea_sub_can_unlock() {
 		wp_set_current_user( $this->reader );
 		delete_user_meta( $this->reader, 'extended_access_sub' );
 
 		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/unlock-article' );
 		$request->set_header( 'X-WP-Post-ID', $this->post );
 
-		$response = $this->server->dispatch( $request );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
 
-		$this->assertEquals( 403, $response->get_status(), 'Users without Extended Access registration should be denied.' );
+		$this->assertEquals( 200, $response->get_status(), 'Logged-in users should be allowed to unlock irrespective of EA registration history.' );
+		$this->assertEquals( 'UNLOCKED', $response_data['status'] );
 	}
-
 }

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -153,7 +153,7 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
 
-		$this->assertFalse( false, $response_data['granted'], 'Anonymous user should not be granted.' );
+		$this->assertFalse( $response_data['granted'], 'Anonymous user should not be granted.' );
 	}
 
 	/**
@@ -176,6 +176,46 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		$this->assertNotEmpty( $response_data['id'] );
 		$this->assertArrayHasKey( 'registrationTimestamp', $response_data, 'Logged-in users must expose `registrationTimestamp`.' );
 		$this->assertIsInt( $response_data['registrationTimestamp'] );
+	}
+
+	/**
+	 * The userState `id` handed to Google for a non-EA reader must be opaque:
+	 * stable across requests, but not decodable back to the internal WordPress
+	 * user ID (which is sequential and therefore enumerable).
+	 */
+	public function test_login_status__derived_id_does_not_leak_wp_user_id() {
+		wp_set_current_user( $this->reader );
+		delete_user_meta( $this->reader, 'extended_access_sub' );
+
+		$request       = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$response_data = $this->server->dispatch( $request )->get_data();
+		$user_state_id = $response_data['id'];
+
+		$this->assertStringNotContainsString( (string) $this->reader, $user_state_id, 'The derived id must not embed the WP user ID.' );
+		$this->assertNotEquals( 'wp_' . $this->reader, base64_decode( $user_state_id ), 'The derived id must not be a reversible encoding of the WP user ID.' );
+
+		// Stable: a second request for the same reader yields the same id, so
+		// Google can still correlate the reader across visits.
+		$second_response_data = $this->server->dispatch( new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' ) )->get_data();
+		$this->assertEquals( $user_state_id, $second_response_data['id'], 'The derived id must be stable for a given reader.' );
+	}
+
+	/**
+	 * The unlock cookie name is hashed from the post ID, so a non-canonical
+	 * numeric `X-WP-Post-ID` header (e.g. "042" or " 42") must normalise to the
+	 * same value the unlock endpoint used — otherwise a granted metering cookie
+	 * would never be found again.
+	 */
+	public function test_login_status__non_canonical_post_id_header_still_resolves_metering() {
+		wp_set_current_user( $this->reader );
+		delete_user_meta( $this->reader, 'extended_access_sub' );
+
+		$request = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$request->set_header( 'X-WP-Post-ID', '0' . $this->post );
+		$response_data = $this->server->dispatch( $request )->get_data();
+
+		$this->assertTrue( $response_data['granted'], 'A zero-padded post ID header must resolve to the same unlock cookie.' );
+		$this->assertEquals( 'METERING', $response_data['grantReason'] );
 	}
 
 	/**

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -8,6 +8,16 @@
 use Newspack\ExtendedAccess;
 
 require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
+
+// Provide a controllable stub for WC Memberships' access check so tests can
+// exercise the SUBSCRIBER code path without installing the (paid) plugin.
+// Behaviour is toggled per-test via the $GLOBALS['newspack_ea_test_wc_memberships_user_can'] flag.
+if ( ! function_exists( 'wc_memberships_user_can' ) ) {
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- signature must match WC Memberships'.
+	function wc_memberships_user_can( $user_id, $action, $args = array() ) {
+		return ! empty( $GLOBALS['newspack_ea_test_wc_memberships_user_can'] );
+	}
+}
 /**
  * Tests REST API Controller.
  */
@@ -43,6 +53,10 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		// Reset the controllable WC Memberships stub between tests so a single
+		// SUBSCRIBER-path test can't leak access into unrelated assertions.
+		$GLOBALS['newspack_ea_test_wc_memberships_user_can'] = false;
 
 		// Setup Server to mock requests.
 		global $wp_rest_server;
@@ -99,17 +113,69 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures non registered user should not be granted.
+	 * A logged-in user without an `extended_access_sub` meta (i.e. registered
+	 * via channels other than Google Extended Access) must still be returned
+	 * to Google as a *registered* user — `id` and `registrationTimestamp` are
+	 * the spec's signal that the visitor isn't anonymous. Without them, Google
+	 * would show the registration intervention over an already-known reader.
 	 */
-	public function test_login_status__non_registered_reader() {
-		// Set to Newspack Reader user.
+	public function test_login_status__logged_in_user_without_ea_sub_is_recognised_as_registered() {
 		wp_set_current_user( $this->reader );
+		delete_user_meta( $this->reader, 'extended_access_sub' );
 
 		$request       = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
 
-		$this->assertFalse( $response_data['granted'], 'Non registered subscriber user should not be granted.' );
+		$this->assertFalse( $response_data['granted'], 'Reader without subscription or metering cookie should not be granted.' );
+		$this->assertArrayHasKey( 'id', $response_data, 'Logged-in users must expose an `id` so Google treats them as registered.' );
+		$this->assertNotEmpty( $response_data['id'] );
+		$this->assertArrayHasKey( 'registrationTimestamp', $response_data, 'Logged-in users must expose `registrationTimestamp`.' );
+		$this->assertIsInt( $response_data['registrationTimestamp'] );
+	}
+
+	/**
+	 * A logged-in user without an `extended_access_sub` meta who holds a
+	 * metering unlock cookie for the requested post must be reported as
+	 * `granted: true, grantReason: 'METERING'`. Previously the metering path
+	 * was gated on the EA-registered sub, so non-EA-registered readers fell
+	 * through to a `granted: false` even with a valid cookie.
+	 */
+	public function test_login_status__non_ea_user_with_metering_cookie_is_metered() {
+		wp_set_current_user( $this->reader );
+		delete_user_meta( $this->reader, 'extended_access_sub' );
+
+		$request = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$request->set_header( 'X-WP-Post-ID', $this->post );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertTrue( $response_data['granted'], 'Reader with metering cookie should be granted.' );
+		$this->assertEquals( 'METERING', $response_data['grantReason'] );
+		$this->assertArrayHasKey( 'id', $response_data );
+	}
+
+	/**
+	 * A logged-in publisher subscriber who never registered via Google EA must
+	 * still be reported as `granted: true, grantReason: 'SUBSCRIBER'`. This is
+	 * the spec scenario "Registered user with access through a publisher
+	 * subscription" — Google must not show interventions over a subscriber's
+	 * article, regardless of how the subscriber's account was created.
+	 */
+	public function test_login_status__non_ea_subscriber_returns_subscriber_state() {
+		wp_set_current_user( $this->reader );
+		delete_user_meta( $this->reader, 'extended_access_sub' );
+		$GLOBALS['newspack_ea_test_wc_memberships_user_can'] = true;
+
+		$request = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$request->set_header( 'X-WP-Post-ID', $this->post );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertTrue( $response_data['granted'], 'Subscriber should be granted regardless of EA registration history.' );
+		$this->assertEquals( 'SUBSCRIBER', $response_data['grantReason'] );
+		$this->assertArrayHasKey( 'id', $response_data );
+		$this->assertArrayHasKey( 'subscriptionTimestamp', $response_data );
 	}
 
 	/**

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -191,13 +191,24 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		$response_data = $this->server->dispatch( $request )->get_data();
 		$user_state_id = $response_data['id'];
 
-		$this->assertStringNotContainsString( (string) $this->reader, $user_state_id, 'The derived id must not embed the WP user ID.' );
-		$this->assertNotEquals( 'wp_' . $this->reader, base64_decode( $user_state_id ), 'The derived id must not be a reversible encoding of the WP user ID.' );
+		// Not the user ID, and not any reversible encoding of it. Note that a
+		// substring check on the ID's digits would be meaningless here: a hex
+		// digest of a single-digit user ID contains that digit about nine times
+		// out of ten, so such an assertion passes or fails by luck.
+		$this->assertNotEquals( 'wp_' . $this->reader, $user_state_id, 'The derived id must not be the plain WP user ID.' );
+		$this->assertNotEquals( base64_encode( 'wp_' . $this->reader ), $user_state_id, 'The derived id must not be a base64 encoding of the WP user ID.' );
+		$this->assertNotEquals( 'wp_' . $this->reader, base64_decode( $user_state_id ), 'The derived id must not decode back to the WP user ID.' );
+		$this->assertMatchesRegularExpression( '/^wp_[0-9a-f]{32}$/', $user_state_id, 'The derived id should be a keyed digest.' );
 
 		// Stable: a second request for the same reader yields the same id, so
 		// Google can still correlate the reader across visits.
 		$second_response_data = $this->server->dispatch( new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' ) )->get_data();
 		$this->assertEquals( $user_state_id, $second_response_data['id'], 'The derived id must be stable for a given reader.' );
+
+		// Distinct per reader, so Google cannot conflate two readers.
+		wp_set_current_user( $this->subscriber );
+		$other_response_data = $this->server->dispatch( new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' ) )->get_data();
+		$this->assertNotEquals( $user_state_id, $other_response_data['id'], 'Two readers must not share a derived id.' );
 	}
 
 	/**

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -18,6 +18,49 @@ if ( ! function_exists( 'wc_memberships_user_can' ) ) {
 		return ! empty( $GLOBALS['newspack_ea_test_wc_memberships_user_can'] );
 	}
 }
+
+// Lightweight stand-in for a WC_Memberships_User_Membership object, exposing
+// just the `get_start_date()` shape the plugin reads.
+if ( ! class_exists( 'Newspack_EA_Test_Membership_Stub' ) ) {
+	/**
+	 * Stub membership object that mirrors `WC_Memberships_User_Membership::get_start_date()`.
+	 */
+	class Newspack_EA_Test_Membership_Stub {
+		/**
+		 * Start timestamp returned by `get_start_date( 'timestamp' )`.
+		 *
+		 * @var int
+		 */
+		public $start_timestamp;
+
+		/**
+		 * @param int $start_timestamp Membership start timestamp.
+		 */
+		public function __construct( $start_timestamp ) {
+			$this->start_timestamp = $start_timestamp;
+		}
+
+		/**
+		 * @param string $format Format token. Only 'timestamp' is honoured here.
+		 * @return int
+		 */
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- format arg kept for parity with WC.
+		public function get_start_date( $format = 'mysql' ) {
+			return $this->start_timestamp;
+		}
+	}
+}
+
+// Controllable stub for WC Memberships' active-memberships lookup. Tests set
+// $GLOBALS['newspack_ea_test_active_memberships'] to an array of stub objects.
+if ( ! function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- signature must match WC.
+	function wc_memberships_get_user_active_memberships( $user_id ) {
+		return isset( $GLOBALS['newspack_ea_test_active_memberships'] )
+			? $GLOBALS['newspack_ea_test_active_memberships']
+			: array();
+	}
+}
 /**
  * Tests REST API Controller.
  */
@@ -57,6 +100,7 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		// Reset the controllable WC Memberships stub between tests so a single
 		// SUBSCRIBER-path test can't leak access into unrelated assertions.
 		$GLOBALS['newspack_ea_test_wc_memberships_user_can'] = false;
+		$GLOBALS['newspack_ea_test_active_memberships']      = array();
 
 		// Setup Server to mock requests.
 		global $wp_rest_server;
@@ -176,6 +220,63 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 'SUBSCRIBER', $response_data['grantReason'] );
 		$this->assertArrayHasKey( 'id', $response_data );
 		$this->assertArrayHasKey( 'subscriptionTimestamp', $response_data );
+	}
+
+	/**
+	 * `subscriptionTimestamp` must reflect the user's actual membership start
+	 * date, not their WP account creation date. When multiple memberships are
+	 * active, the earliest start date is reported.
+	 */
+	public function test_login_status__subscription_timestamp_uses_membership_start_date() {
+		wp_set_current_user( $this->reader );
+		$GLOBALS['newspack_ea_test_wc_memberships_user_can'] = true;
+
+		$earliest_start                                 = 1_600_000_000;
+		$later_start                                    = 1_700_000_000;
+		$GLOBALS['newspack_ea_test_active_memberships'] = array(
+			new Newspack_EA_Test_Membership_Stub( $later_start ),
+			new Newspack_EA_Test_Membership_Stub( $earliest_start ),
+		);
+
+		$request = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$request->set_header( 'X-WP-Post-ID', $this->post );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 'SUBSCRIBER', $response_data['grantReason'] );
+		$this->assertEquals(
+			$earliest_start,
+			$response_data['subscriptionTimestamp'],
+			'subscriptionTimestamp should be the earliest active membership start date.'
+		);
+		$this->assertNotEquals(
+			$response_data['registrationTimestamp'],
+			$response_data['subscriptionTimestamp'],
+			'subscriptionTimestamp must no longer be hardcoded to the user_registered date.'
+		);
+	}
+
+	/**
+	 * When no active memberships can be resolved, `subscriptionTimestamp`
+	 * gracefully falls back to the registration timestamp so the response
+	 * shape stays spec-compliant.
+	 */
+	public function test_login_status__subscription_timestamp_falls_back_when_memberships_missing() {
+		wp_set_current_user( $this->reader );
+		$GLOBALS['newspack_ea_test_wc_memberships_user_can'] = true;
+		$GLOBALS['newspack_ea_test_active_memberships']      = array();
+
+		$request = new WP_REST_Request( 'GET', $this->api_namespace . '/login/status' );
+		$request->set_header( 'X-WP-Post-ID', $this->post );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 'SUBSCRIBER', $response_data['grantReason'] );
+		$this->assertEquals(
+			$response_data['registrationTimestamp'],
+			$response_data['subscriptionTimestamp'],
+			'Fallback should use the registration timestamp when membership data is unavailable.'
+		);
 	}
 
 	/**

--- a/tests/unit-tests/test-google-extended-access.php
+++ b/tests/unit-tests/test-google-extended-access.php
@@ -27,23 +27,39 @@ class Newspack_Test_Google_ExtendedAccess extends WP_UnitTestCase {
 			}
 		}
 
+		// Reset the SwG script enqueue state so each test starts clean.
+		// WP_UnitTestCase does not reset $wp_scripts between tests, which would
+		// otherwise let a prior enqueue leak into negative-path assertions.
+		wp_dequeue_script( 'newspack-swg' );
+		wp_deregister_script( 'newspack-swg' );
+
 		// Initialize .
 		\Newspack\ExtendedAccess\Google_ExtendedAccess::init();
 
 		// Sample Post(s).
-		$this->post      = get_post( $this->factory->post->create() );
-		$GLOBALS['post'] = $this->post;
+		$this->post = get_post( $this->factory->post->create() );
 	}
 
 	/**
-	 * Test that the routes are all registered.
+	 * Helper: navigate to a URL with the Extended Access query param set, so
+	 * `is_singular('post')` and the GAA query-var check both fire.
+	 *
+	 * @param string $url Target URL.
+	 */
+	private function go_to_with_gaa( $url ) {
+		$separator = strpos( $url, '?' ) === false ? '?' : '&';
+		$this->go_to( $url . $separator . \Newspack\ExtendedAccess\Google_ExtendedAccess::GOOGLE_EA_REQUEST_PARAM . '=' . time() );
+	}
+
+	/**
+	 * Scripts must enqueue on single post pages reached via a Showcase link
+	 * (i.e. when the GAA query parameter is present).
 	 */
 	public function test_should_register_script() {
 		// Disables outputs performed using echo by the class/method being tested. Removing this print output performed by function 'google-account-gsi-client'.
 		$this->setOutputCallback( function() {} );
 
-		// Set the query var required for script enqueuing.
-		set_query_var( \Newspack\ExtendedAccess\Google_ExtendedAccess::GOOGLE_EA_REQUEST_PARAM, time() );
+		$this->go_to_with_gaa( get_permalink( $this->post ) );
 
 		do_action( 'wp_head' );
 		$this->assertTrue( wp_script_is( 'newspack-swg', 'registered' ) );
@@ -58,4 +74,32 @@ class Newspack_Test_Google_ExtendedAccess extends WP_UnitTestCase {
         // phpcs:enable
 	}
 
+	/**
+	 * LD+JSON schema must NOT appear on non-singular-post views such as the
+	 * front page, archives, or pages — `@type: Article` is incorrect for those
+	 * and would confuse Google's Extended Access detection.
+	 */
+	public function test_ld_json_not_emitted_on_non_post_views() {
+		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$this->go_to( get_permalink( $page_id ) );
+
+		ob_start();
+		\Newspack\ExtendedAccess\Google_ExtendedAccess::add_extended_access_ld_json();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'newspack-extended-access-schema', $output, 'LD+JSON should not be emitted on pages.' );
+	}
+
+	/**
+	 * Scripts must NOT enqueue on non-singular-post views, even when the GAA
+	 * query parameter is present, so the SwG library only loads on article
+	 * pages.
+	 */
+	public function test_scripts_not_enqueued_on_non_post_views() {
+		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$this->go_to_with_gaa( get_permalink( $page_id ) );
+
+		do_action( 'wp_head' );
+		$this->assertFalse( wp_script_is( 'newspack-swg', 'enqueued' ), 'newspack-swg must not load on pages.' );
+	}
 }

--- a/tests/unit-tests/test-google-jwt.php
+++ b/tests/unit-tests/test-google-jwt.php
@@ -241,6 +241,86 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 	}
 
 	/**
+	 * RFC 7519 allows `aud` to be an array of strings as well as a single
+	 * string. A token whose audience array contains our client ID is valid and
+	 * must not be rejected.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_accepts_array_audience_containing_client_id(): void {
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 2048,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+		$public_key_details = openssl_pkey_get_details( $private_key );
+		$kid                = 'test-key-id';
+		$jwk_key_set        = $this->convert_rsa_to_jwk( $public_key_details, $kid );
+
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
+
+		$message = [
+			'iss' => 'https://accounts.google.com',
+			'aud' => [ 'other-client.apps.googleusercontent.com', 'client-id.apps.googleusercontent.com' ],
+			'iat' => time() - 60,
+			'nbf' => time() - 60,
+			'exp' => time() + 3600,
+		];
+
+		$jwt        = JWT::encode( $message, $private_key, 'RS256', $kid );
+		$google_jwt = new Google_Jwt( $jwt );
+		$result     = $google_jwt->decode();
+
+		$this->assertNotWPError( $result );
+	}
+
+	/**
+	 * An array audience that does *not* contain our client ID must still be
+	 * rejected — the array shape widens what is accepted, it does not bypass
+	 * the check.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_rejects_array_audience_without_client_id(): void {
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 2048,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+		$public_key_details = openssl_pkey_get_details( $private_key );
+		$kid                = 'test-key-id';
+		$jwk_key_set        = $this->convert_rsa_to_jwk( $public_key_details, $kid );
+
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
+
+		$message = [
+			'iss' => 'https://accounts.google.com',
+			'aud' => [ 'other-client.apps.googleusercontent.com', 'third-client.apps.googleusercontent.com' ],
+			'azp' => 'client-id.apps.googleusercontent.com',
+			'iat' => time() - 60,
+			'nbf' => time() - 60,
+			'exp' => time() + 3600,
+		];
+
+		$jwt        = JWT::encode( $message, $private_key, 'RS256', $kid );
+		$google_jwt = new Google_Jwt( $jwt );
+		$result     = $google_jwt->decode();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_extended_access_google_token', $result->get_error_code() );
+	}
+
+	/**
 	 * Test the function that checks if we should refresh the JWKS cache.
 	 * Case: The cache is outdated.
 	 *

--- a/tests/unit-tests/test-google-jwt.php
+++ b/tests/unit-tests/test-google-jwt.php
@@ -38,7 +38,7 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 		$private_key = openssl_pkey_new(
 			array(
 				'digest_alg'       => 'sha256',
-				'private_key_bits' => 1024,
+				'private_key_bits' => 2048,
 				'private_key_type' => OPENSSL_KEYTYPE_RSA,
 			)
 		);
@@ -54,15 +54,15 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 
 		// Update the options.
 		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
-		update_option( 'newspack_extended_access__google_client_api_id', 'authorized-party' );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
 
 		// Create a message.
 		$message = [
-			'iss' => 'http://google.org',
-			'aud' => 'http://google.com',
+			'iss' => 'https://accounts.google.com',
+			'aud' => 'client-id.apps.googleusercontent.com',
 			'iat' => 1356999524,
 			'nbf' => 1357000000,
-			'azp' => 'authorized-party',
+			'azp' => 'client-id.apps.googleusercontent.com',
 			'exp' => time() + 3600,
 		];
 
@@ -100,7 +100,7 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 		$private_key = openssl_pkey_new(
 			array(
 				'digest_alg'       => 'sha256',
-				'private_key_bits' => 1024,
+				'private_key_bits' => 2048,
 				'private_key_type' => OPENSSL_KEYTYPE_RSA,
 			)
 		);
@@ -119,15 +119,15 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 		// Update the options.
 		// Update the cache with the invalid JWK key set to simulate an outdated cache.
 		update_option( Google_Jwt::CACHE_OPTION_NAME, $invalid_jwk_key_set );
-		update_option( 'newspack_extended_access__google_client_api_id', 'authorized-party' );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
 
 		// Create a message.
 		$message = [
-			'iss' => 'http://google.org',
-			'aud' => 'http://google.com',
+			'iss' => 'https://accounts.google.com',
+			'aud' => 'client-id.apps.googleusercontent.com',
 			'iat' => 1356999524,
 			'nbf' => 1357000000,
-			'azp' => 'authorized-party',
+			'azp' => 'client-id.apps.googleusercontent.com',
 			'exp' => time() + 3600,
 		];
 
@@ -158,6 +158,86 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 
 		// Assert the message.
 		$this->assertEquals( $message, (array) $result );
+	}
+
+	/**
+	 * Test the decode() function rejects tokens with an invalid issuer.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_rejects_invalid_issuer(): void {
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 2048,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+		$public_key_details = openssl_pkey_get_details( $private_key );
+		$kid                = 'test-key-id';
+		$jwk_key_set        = $this->convert_rsa_to_jwk( $public_key_details, $kid );
+
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
+
+		// Issuer is not one of Google's accepted values.
+		$message = [
+			'iss' => 'https://evil.example.com',
+			'aud' => 'client-id.apps.googleusercontent.com',
+			'iat' => time() - 60,
+			'nbf' => time() - 60,
+			'exp' => time() + 3600,
+		];
+
+		$jwt        = JWT::encode( $message, $private_key, 'RS256', $kid );
+		$google_jwt = new Google_Jwt( $jwt );
+		$result     = $google_jwt->decode();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_extended_access_google_token', $result->get_error_code() );
+	}
+
+	/**
+	 * Test the decode() function rejects tokens with a mismatched audience.
+	 *
+	 * @covers Newspack\ExtendedAccess\Google_Jwt::decode
+	 *
+	 * @return void
+	 */
+	public function test_decode_rejects_invalid_audience(): void {
+		$private_key = openssl_pkey_new(
+			array(
+				'digest_alg'       => 'sha256',
+				'private_key_bits' => 2048,
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+			)
+		);
+		$public_key_details = openssl_pkey_get_details( $private_key );
+		$kid                = 'test-key-id';
+		$jwk_key_set        = $this->convert_rsa_to_jwk( $public_key_details, $kid );
+
+		update_option( Google_Jwt::CACHE_OPTION_NAME, $jwk_key_set );
+		update_option( 'newspack_extended_access__google_client_api_id', 'client-id.apps.googleusercontent.com' );
+
+		// Audience is a different Google client. `azp` matches ours, which is what the
+		// old (vulnerable) implementation would have accepted.
+		$message = [
+			'iss' => 'https://accounts.google.com',
+			'aud' => 'other-client.apps.googleusercontent.com',
+			'azp' => 'client-id.apps.googleusercontent.com',
+			'iat' => time() - 60,
+			'nbf' => time() - 60,
+			'exp' => time() + 3600,
+		];
+
+		$jwt        = JWT::encode( $message, $private_key, 'RS256', $kid );
+		$google_jwt = new Google_Jwt( $jwt );
+		$result     = $google_jwt->decode();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_extended_access_google_token', $result->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
- https://github.com/Automattic/newspack-extended-access/commit/52e665d24efbe0d075c8ef17d1ecb9cde45dfe0e adjusts the JWT handling to better follow the official spec.
- https://github.com/Automattic/newspack-extended-access/commit/1aad4daef3ab1a5f4416d0813fac4cfb347a80c7 adjusts the flow to allow existing logged in users access to articles
- https://github.com/Automattic/newspack-extended-access/commit/13497de216275dacfaf75094294a43a2b48ef67c adds handling for subscription start dates on existing users
- https://github.com/Automattic/newspack-extended-access/commit/df179134919c675ebb5f3178b6be242ce7c3f6a1 adjusts it to only output the JSON LD markup on single posts (previously it was doing search results and articles)
- https://github.com/Automattic/newspack-extended-access/commit/a15431381c972fa3c06b0cb417e8dd25a6c61fc8 fixes some logic in the flow that was making it not meet the official spec for how it should behave.