### PR TITLE
feat: honor Google Extended Access unlocks under Access Control gating (NPPD-1901)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -54,5 +54,9 @@ jobs:
       - name: Setup WordPress test environment
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
 
+      # Runs each testsuite as its own process, which is what keeps the
+      # NEWSPACK_CONTENT_GATES define in the Access Control suite from leaking
+      # into a suite that asserts flag-off behaviour. A bare phpunit run would
+      # rely on suite ordering alone.
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: composer test

--- a/assets/js/newspack-swg.js
+++ b/assets/js/newspack-swg.js
@@ -48,11 +48,16 @@ function initGaaMetering() {
 		() => {
 			GaaMetering.getLoginPromise().then(
 				() => {
-					// Capture full URL, including URL parameters, to redirect the user to after login
-					const redirectUri = encodeURIComponent(window.location.href);
-					// Redirect to a login page for existing users to login.
+					// Capture the full URL, including query parameters, to return the reader to
+					// after login. The Extended Access parameters live there and not in the
+					// permalink, so dropping them leaves the flow unable to resume.
+					const loginUrl = new URL(authenticationSettings.myAccountURL, window.location.origin);
 					// 'redirect' param is used by newspack plugin's reader-activation to prepare auth callback URL.
-					window.location = `${authenticationSettings.myAccountURL}?redirect=${redirectUri}`;
+					loginUrl.searchParams.set('redirect', window.location.href);
+					// 'redirect_to' is what wp-login.php honours, on sites with no My Account page.
+					loginUrl.searchParams.set('redirect_to', window.location.href);
+					// Redirect to a login page for existing users to login.
+					window.location = loginUrl.toString();
 				}
 			);
 		}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
     ]
   },
   "scripts": {
-    "test": "phpunit"
+    "test": [
+      "phpunit --testsuite 'Newspack Test Suite'",
+      "phpunit --testsuite 'Access Control Integration'"
+    ]
   },
   "config": {
     "allow-plugins": {

--- a/includes/class-dependencychecker.php
+++ b/includes/class-dependencychecker.php
@@ -110,6 +110,41 @@ class DependencyChecker {
 	}
 
 	/**
+	 * The Access Control implementation of `newspack_post_has_restrictions`.
+	 *
+	 * Held as a constant so the runtime check below and the tests that assert
+	 * it stay in sync. Spelled without a leading backslash to match the id WP
+	 * builds for the registered callback.
+	 *
+	 * @var array
+	 */
+	const NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK = array( 'Newspack\Content_Restriction_Control', 'post_has_restrictions' );
+
+	/**
+	 * Check whether Access Control can answer whether a post is gated at all.
+	 *
+	 * `Content_Gate::post_has_restrictions()` is a thin wrapper over the
+	 * `newspack_post_has_restrictions` filter and returns false whenever
+	 * nothing answers it, which is indistinguishable from a genuinely ungated
+	 * post. Reading the LD+JSON schema off that default would advertise every
+	 * gated article as accessible for free, so callers skip the schema
+	 * entirely rather than emit a wrong answer.
+	 *
+	 * The Access Control implementation is looked for by name because the
+	 * Woo Memberships one registers on the same filter unconditionally - it
+	 * passes its input straight through when Memberships is inactive, so a
+	 * bare `has_filter()` is true on every site and proves nothing. If that
+	 * callback is ever renamed this check goes false and the schema is
+	 * omitted, which is the safe direction to fail in.
+	 *
+	 * @return bool Return true if the restriction state is knowable.
+	 */
+	public static function is_newspack_restriction_state_available(): bool {
+		return self::is_newspack_access_control_active()
+			&& false !== has_filter( 'newspack_post_has_restrictions', self::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK );
+	}
+
+	/**
 	 * Check whether the WooCommerce Memberships gating stack is fully active.
 	 *
 	 * @return bool Return true if WooCommerce and WooCommerce Memberships are installed and active.

--- a/includes/class-dependencychecker.php
+++ b/includes/class-dependencychecker.php
@@ -119,6 +119,17 @@ class DependencyChecker {
 	}
 
 	/**
+	 * Check whether the WooCommerce Memberships plugin code is loaded in this
+	 * request. The single runtime predicate for branching between the WCM and
+	 * Newspack Access Control integrations.
+	 *
+	 * @return bool Return true if WooCommerce Memberships is loaded.
+	 */
+	public static function is_wc_memberships_loaded(): bool {
+		return function_exists( 'wc_memberships' );
+	}
+
+	/**
 	 * Check whether Google Client API ID is valid or not.
 	 *
 	 * @return bool Return true if valid Google Client API ID is present.

--- a/includes/class-dependencychecker.php
+++ b/includes/class-dependencychecker.php
@@ -98,6 +98,27 @@ class DependencyChecker {
 	}
 
 	/**
+	 * Check whether the first-party Newspack Access Control (content gates)
+	 * system is available and enabled.
+	 *
+	 * @return bool Return true if Access Control is active.
+	 */
+	public static function is_newspack_access_control_active(): bool {
+		return class_exists( '\Newspack\Content_Gate' )
+			&& is_callable( array( '\Newspack\Content_Gate', 'is_newspack_feature_enabled' ) )
+			&& \Newspack\Content_Gate::is_newspack_feature_enabled();
+	}
+
+	/**
+	 * Check whether the WooCommerce Memberships gating stack is fully active.
+	 *
+	 * @return bool Return true if WooCommerce and WooCommerce Memberships are installed and active.
+	 */
+	public static function is_wc_memberships_stack_active(): bool {
+		return self::is_wc_installed() && self::is_wc_active() && self::is_wc_memberships_installed() && self::is_wc_memberships_active();
+	}
+
+	/**
 	 * Check whether Google Client API ID is valid or not.
 	 *
 	 * @return bool Return true if valid Google Client API ID is present.

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -48,8 +48,18 @@ class Google_ExtendedAccess {
 		if ( ! self::can_insert_frontend_markup() ) {
 			return;
 		}
-		// 'wc_memberships_is_post_content_restricted()' function will only available if WooCommerce Membership plugin is installed and active.
+
+		// Whether the post is covered by content gating rules, from whichever
+		// gating system is active.
+		$is_post_restricted = null;
 		if ( function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
+			// 'wc_memberships_is_post_content_restricted()' function will only be available if WooCommerce Memberships plugin is installed and active.
+			$is_post_restricted = wc_memberships_is_post_content_restricted();
+		} elseif ( DependencyChecker::is_newspack_access_control_active() ) {
+			$is_post_restricted = \Newspack\Content_Gate::post_has_restrictions( get_the_ID() );
+		}
+
+		if ( null !== $is_post_restricted ) {
 			// Add 'isAccessibleForFree' schema for compatibility with Google Extended Access.
 			$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
@@ -59,7 +69,7 @@ class Google_ExtendedAccess {
 			$ld_json = array(
 				'@context'            => 'https://schema.org',
 				'@type'               => 'Article',
-				'isAccessibleForFree' => ! wc_memberships_is_post_content_restricted(),
+				'isAccessibleForFree' => ! $is_post_restricted,
 				'isPartOf'            => array(
 					'@type'     => array( 'CreativeWork', 'Product' ),
 					'name'      => get_bloginfo( 'name' ),
@@ -118,6 +128,10 @@ class Google_ExtendedAccess {
 			$home_url_parts    = wp_parse_url( home_url() );
 			$allowed_referrers = array( $home_url_parts['host'] );
 
+			// The reader-facing account page: WooCommerce's My Account when
+			// available, otherwise the login URL redirecting back to the post.
+			$my_account_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url();
+
 			// Nonce for REST API.
 			wp_localize_script(
 				'newspack-swg',
@@ -127,7 +141,7 @@ class Google_ExtendedAccess {
 					'allowedReferrers'  => $allowed_referrers,
 					'postID'            => get_the_ID(),
 					'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
-					'myAccountURL'      => wc_get_page_permalink( 'myaccount' )
+					'myAccountURL'      => $my_account_url,
 				)
 			);
 

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -50,47 +50,61 @@ class Google_ExtendedAccess {
 		}
 
 		// Whether the post is covered by content gating rules, from whichever
-		// gating system is active.
+		// gating system is active. Stays null when no gating system can answer,
+		// in which case no schema is emitted at all: a wrong answer here tells
+		// Google that gated content is free.
 		$is_post_restricted = null;
 		if ( DependencyChecker::is_wc_memberships_loaded() ) {
 			$is_post_restricted = wc_memberships_is_post_content_restricted();
-		} elseif ( DependencyChecker::is_newspack_access_control_active() ) {
+		} elseif ( DependencyChecker::is_newspack_restriction_state_available() ) {
 			$is_post_restricted = \Newspack\Content_Gate::post_has_restrictions( get_the_ID() );
 		}
 
 		if ( null !== $is_post_restricted ) {
-			// Add 'isAccessibleForFree' schema for compatibility with Google Extended Access.
-			$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
-			$url_parts = wp_parse_url( home_url() );
-			$domain    = str_replace( 'www.', '', $url_parts['host'] );
-
-			$ld_json = array(
-				'@context'            => 'https://schema.org',
-				'@type'               => 'Article',
-				'isAccessibleForFree' => ! $is_post_restricted,
-				'isPartOf'            => array(
-					'@type'     => array( 'CreativeWork', 'Product' ),
-					'name'      => get_bloginfo( 'name' ),
-					'productID' => $domain . ':showcase',
-				),
-				'publisher'           => array(
-					'@type' => 'Organization',
-					'name'  => get_bloginfo( 'name' ),
-				),
-			);
-
-			$ld_json = wp_json_encode( $ld_json, $flags );
-			$ld_json = str_replace( "\n", PHP_EOL . "\t", $ld_json );
-			?>
-			<script type="application/ld+json" class="newspack-extended-access-schema">
-				<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $ld_json;
-				?>
-			</script>
-			<?php
+			self::render_extended_access_ld_json( (bool) $is_post_restricted );
 		}
+	}
+
+	/**
+	 * Renders the LD+JSON schema for a known restriction state.
+	 *
+	 * Separate from the branching above so the schema's shape is exercised
+	 * independently of which gating system supplied the state.
+	 *
+	 * @param bool $is_post_restricted Whether the post is covered by gating rules.
+	 */
+	public static function render_extended_access_ld_json( bool $is_post_restricted ) {
+		// Add 'isAccessibleForFree' schema for compatibility with Google Extended Access.
+		$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		$url_parts = wp_parse_url( home_url() );
+		$domain    = str_replace( 'www.', '', $url_parts['host'] );
+
+		$ld_json = array(
+			'@context'            => 'https://schema.org',
+			'@type'               => 'Article',
+			'isAccessibleForFree' => ! $is_post_restricted,
+			'isPartOf'            => array(
+				'@type'     => array( 'CreativeWork', 'Product' ),
+				'name'      => get_bloginfo( 'name' ),
+				'productID' => $domain . ':showcase',
+			),
+			'publisher'           => array(
+				'@type' => 'Organization',
+				'name'  => get_bloginfo( 'name' ),
+			),
+		);
+
+		$ld_json = wp_json_encode( $ld_json, $flags );
+		$ld_json = str_replace( "\n", PHP_EOL . "\t", $ld_json );
+		?>
+		<script type="application/ld+json" class="newspack-extended-access-schema">
+			<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $ld_json;
+			?>
+		</script>
+		<?php
 	}
 
 	/**

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -142,13 +142,14 @@ class Google_ExtendedAccess {
 			$allowed_referrers = array( $home_url_parts['host'] );
 
 			/*
-			 * The page the SwG script sends existing readers to for logging in.
-			 * WooCommerce's My Account when available (Newspack reader
-			 * activation handles the script's appended `redirect` param there);
-			 * otherwise the WP login URL with `redirect_to` pre-set to the
-			 * current article, so the reader returns to it after logging in.
+			 * The page the SwG script sends existing readers to for logging in:
+			 * WooCommerce's My Account when available, otherwise the WP login
+			 * URL. Both are handed over bare - the script appends the return
+			 * destination itself, from the live URL rather than the permalink,
+			 * so the Extended Access query args needed to resume the flow after
+			 * login survive the round trip.
 			 */
-			$my_account_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url( get_permalink() );
+			$my_account_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url();
 
 			// Nonce for REST API.
 			wp_localize_script(

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -52,8 +52,7 @@ class Google_ExtendedAccess {
 		// Whether the post is covered by content gating rules, from whichever
 		// gating system is active.
 		$is_post_restricted = null;
-		if ( function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
-			// 'wc_memberships_is_post_content_restricted()' function will only be available if WooCommerce Memberships plugin is installed and active.
+		if ( DependencyChecker::is_wc_memberships_loaded() ) {
 			$is_post_restricted = wc_memberships_is_post_content_restricted();
 		} elseif ( DependencyChecker::is_newspack_access_control_active() ) {
 			$is_post_restricted = \Newspack\Content_Gate::post_has_restrictions( get_the_ID() );
@@ -128,9 +127,14 @@ class Google_ExtendedAccess {
 			$home_url_parts    = wp_parse_url( home_url() );
 			$allowed_referrers = array( $home_url_parts['host'] );
 
-			// The reader-facing account page: WooCommerce's My Account when
-			// available, otherwise the login URL redirecting back to the post.
-			$my_account_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url();
+			/*
+			 * The page the SwG script sends existing readers to for logging in.
+			 * WooCommerce's My Account when available (Newspack reader
+			 * activation handles the script's appended `redirect` param there);
+			 * otherwise the WP login URL with `redirect_to` pre-set to the
+			 * current article, so the reader returns to it after logging in.
+			 */
+			$my_account_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url( get_permalink() );
 
 			// Nonce for REST API.
 			wp_localize_script(

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -30,7 +30,16 @@ class Initializer {
 		WooCommerce::init();
 		WC_Settings_Memberships_Option_Tab::init();
 
-		// Initialize classes only when all dependencies are met.
+		// Defer the dependency-gated initialization until all plugins are
+		// loaded: the Newspack Access Control classes belong to the Newspack
+		// plugin, which may load after this plugin.
+		add_action( 'plugins_loaded', array( __CLASS__, 'init_dependent_classes' ) );
+	}
+
+	/**
+	 * Initialize classes only when all dependencies are met.
+	 */
+	public static function init_dependent_classes() {
 		if ( self::has_valid_dependencies() ) {
 			REST_Controller::init();
 			Google_ExtendedAccess::init();
@@ -41,13 +50,17 @@ class Initializer {
 	/**
 	 * Check and displays plugin specific notices when required.
 	 *
+	 * Extended Access requires a configured Google Client API ID and a content
+	 * gating system: either the WooCommerce Memberships stack or the
+	 * first-party Newspack Access Control.
+	 *
 	 * @return bool Return false on error.
 	 */
 	public static function has_valid_dependencies() {
-		if ( ! DependencyChecker::is_wc_installed() || ! DependencyChecker::is_wc_active() || ! DependencyChecker::is_wc_memberships_installed() || ! DependencyChecker::is_wc_memberships_active() || ! DependencyChecker::is_valid_google_client_api_id() ) {
+		if ( ! DependencyChecker::is_valid_google_client_api_id() ) {
 			return false;
 		}
-		return true;
+		return DependencyChecker::is_wc_memberships_stack_active() || DependencyChecker::is_newspack_access_control_active();
 	}
 
 	/**
@@ -62,14 +75,8 @@ class Initializer {
 			'b' => array(),
 		);
 
-		if ( ! DependencyChecker::is_wc_installed() ) {
-			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>WooCommerce</b> to be installed, active and configured.';
-		} elseif ( ! DependencyChecker::is_wc_active() ) {
-			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>WooCommerce</b> to be active. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
-		} elseif ( ! DependencyChecker::is_wc_memberships_installed() ) {
-			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>WooCommerce Memberships</b> to be installed, active and configured.';
-		} elseif ( ! DependencyChecker::is_wc_memberships_active() ) {
-			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>WooCommerce Memberships</b> to be active. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
+		if ( ! DependencyChecker::is_wc_memberships_stack_active() && ! DependencyChecker::is_newspack_access_control_active() ) {
+			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires a content gating system: either <b>Newspack Access Control</b> (content gates) or <b>WooCommerce</b> with <b>WooCommerce Memberships</b>. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
 		} elseif ( ! DependencyChecker::is_valid_google_client_api_id() ) {
 			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Please check your <b>Google Client API ID</b> into <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=memberships&section=newspack-extended-access' ) ) . '">Newspack Extended Access Settings</a>.';
 		}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -69,16 +69,23 @@ class Initializer {
 	public static function show_admin_notice__error() {
 		$plugin_notice = '';
 		$allowed_html  = array(
-			'a' => array(
+			'a'    => array(
 				'href' => array(),
 			),
-			'b' => array(),
+			'b'    => array(),
+			'code' => array(),
 		);
 
 		if ( ! DependencyChecker::is_wc_memberships_stack_active() && ! DependencyChecker::is_newspack_access_control_active() ) {
 			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires a content gating system: either <b>Newspack Access Control</b> (content gates) or <b>WooCommerce</b> with <b>WooCommerce Memberships</b>. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
 		} elseif ( ! DependencyChecker::is_valid_google_client_api_id() ) {
-			$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Please check your <b>Google Client API ID</b> into <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=memberships&section=newspack-extended-access' ) ) . '">Newspack Extended Access Settings</a>.';
+			if ( DependencyChecker::is_wc_memberships_stack_active() ) {
+				$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Please check your <b>Google Client API ID</b> into <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=memberships&section=newspack-extended-access' ) ) . '">Newspack Extended Access Settings</a>.';
+			} else {
+				// Without WooCommerce Memberships there is no settings screen for
+				// this option; point at the option itself until one exists.
+				$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Set the <code>newspack_extended_access__google_client_api_id</code> option to your Google Client API ID, e.g. via WP-CLI: <code>wp option update newspack_extended_access__google_client_api_id your-client-id.apps.googleusercontent.com</code>.';
+			}
 		}
 
 		if ( ! empty( $plugin_notice ) ) {

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -66,19 +66,43 @@ class REST_Controller {
 		if ( ! $post_id || ! DependencyChecker::is_newspack_access_control_active() ) {
 			return false;
 		}
-		// The Access Control check evaluates the current session only.
+		/*
+		 * The Access Control check evaluates the current session only, so a
+		 * mismatch cannot be answered rather than denied. Every caller reaches
+		 * here after Reader_Activation::set_current_reader(), so this is loud
+		 * instead of a quiet denial: a caller that stops setting the current
+		 * reader would otherwise downgrade a genuine subscriber to a metered
+		 * single-article unlock with no visible symptom.
+		 */
 		if ( get_current_user_id() !== (int) $user_id ) {
+			_doing_it_wrong(
+				__METHOD__,
+				'The Access Control access check can only answer for the current user.',
+				'1.2.0'
+			);
 			return false;
 		}
 
 		/*
 		 * Evaluate the underlying gate access without the Extended Access unlock
 		 * filter: a metered unlock must not report as full (SUBSCRIBER) access.
+		 *
+		 * Restore exactly what was removed, at the priority it was registered at,
+		 * and do it in a finally: a gate access rule that throws must not leave
+		 * the front-end unlock lifting disabled for the rest of the request.
 		 */
-		remove_filter( 'newspack_is_post_restricted', array( SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' ), 20 );
-		$can_view = ! \Newspack\Content_Gate::is_post_restricted( (int) $post_id );
-		add_filter( 'newspack_is_post_restricted', array( SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' ), 20, 2 );
-		return $can_view;
+		$unlock_filter       = array( SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' );
+		$registered_priority = has_filter( 'newspack_is_post_restricted', $unlock_filter );
+		if ( false !== $registered_priority ) {
+			remove_filter( 'newspack_is_post_restricted', $unlock_filter, $registered_priority );
+		}
+		try {
+			return ! \Newspack\Content_Gate::is_post_restricted( (int) $post_id );
+		} finally {
+			if ( false !== $registered_priority ) {
+				add_filter( 'newspack_is_post_restricted', $unlock_filter, $registered_priority, 2 );
+			}
+		}
 	}
 
 	/**

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -48,6 +48,28 @@ class REST_Controller {
 	}
 
 	/**
+	 * Whether the user has full access to the post through the active content
+	 * gating system (e.g. a membership or a satisfied content gate), meaning
+	 * no metered unlock is needed.
+	 *
+	 * The user must be the current user: the Newspack Access Control check
+	 * evaluates gate access rules for the current session.
+	 *
+	 * @param int $user_id The user ID.
+	 * @param int $post_id The post ID.
+	 * @return bool
+	 */
+	private static function can_user_view_post( $user_id, $post_id ) {
+		if ( function_exists( 'wc_memberships_user_can' ) ) {
+			return (bool) wc_memberships_user_can( $user_id, 'view', array( 'post' => $post_id ) );
+		}
+		if ( $post_id && DependencyChecker::is_newspack_access_control_active() ) {
+			return ! \Newspack\Content_Gate::is_post_restricted( (int) $post_id );
+		}
+		return false;
+	}
+
+	/**
 	 * Registers REST Endpoints for Extended Access.
 	 */
 	public static function register_api_endpoints() {
@@ -142,10 +164,7 @@ class REST_Controller {
 			// At this point the user will be logged in.
 		}
 
-		$member_can_view_post = false;
-		if ( function_exists( 'wc_memberships_user_can' ) ) {
-			$member_can_view_post = wc_memberships_user_can( $user_id, 'view', array( 'post' => $post_id ) );
-		}
+		$member_can_view_post = self::can_user_view_post( $user_id, $post_id );
 
 		if ( $member_can_view_post ) {
 			$response = rest_ensure_response(
@@ -199,10 +218,7 @@ class REST_Controller {
 			return new \WP_Error( 'missing_post_id', 'A valid post ID is required.', array( 'status' => 400 ) );
 		}
 
-		$member_can_view_post = false;
-		if ( function_exists( 'wc_memberships_user_can' ) ) {
-			$member_can_view_post = wc_memberships_user_can( $user_id, 'view', array( 'post' => $post_id ) );
-		}
+		$member_can_view_post = self::can_user_view_post( $user_id, $post_id );
 
 		if ( $member_can_view_post ) {
 			return rest_ensure_response(
@@ -260,10 +276,7 @@ class REST_Controller {
 
 				// Checks if cookie is set, grants access only if cookie is set.
 				if ( $jwt_sub ) {
-					$member_can_view_post = false;
-					if ( function_exists( 'wc_memberships_user_can' ) ) {
-						$member_can_view_post = wc_memberships_user_can( $existing_user->ID, 'view', array( 'post' => $post_id ) );
-					}
+					$member_can_view_post = self::can_user_view_post( $existing_user->ID, $post_id );
 
 					$cookie_name = self::get_unlock_cookie_name( $post_id, $user_id );
 

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -60,13 +60,25 @@ class REST_Controller {
 	 * @return bool
 	 */
 	private static function can_user_view_post( $user_id, $post_id ) {
-		if ( function_exists( 'wc_memberships_user_can' ) ) {
+		if ( DependencyChecker::is_wc_memberships_loaded() ) {
 			return (bool) wc_memberships_user_can( $user_id, 'view', array( 'post' => $post_id ) );
 		}
-		if ( $post_id && DependencyChecker::is_newspack_access_control_active() ) {
-			return ! \Newspack\Content_Gate::is_post_restricted( (int) $post_id );
+		if ( ! $post_id || ! DependencyChecker::is_newspack_access_control_active() ) {
+			return false;
 		}
-		return false;
+		// The Access Control check evaluates the current session only.
+		if ( get_current_user_id() !== (int) $user_id ) {
+			return false;
+		}
+
+		/*
+		 * Evaluate the underlying gate access without the Extended Access unlock
+		 * filter: a metered unlock must not report as full (SUBSCRIBER) access.
+		 */
+		remove_filter( 'newspack_is_post_restricted', array( SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' ), 20 );
+		$can_view = ! \Newspack\Content_Gate::is_post_restricted( (int) $post_id );
+		add_filter( 'newspack_is_post_restricted', array( SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' ), 20, 2 );
+		return $can_view;
 	}
 
 	/**
@@ -133,7 +145,7 @@ class REST_Controller {
 		$email = $token->email;
 
 		$existing_user = get_user_by( 'email', $email );
-		$post_id       = $request->get_header( 'X-WP-Post-ID' );
+		$post_id       = absint( $request->get_header( 'X-WP-Post-ID' ) );
 		$user_id       = false;
 		$granted       = false;
 
@@ -249,7 +261,7 @@ class REST_Controller {
 	 */
 	public static function api_verify_user( $request ) {
 		$logged_in_user = wp_get_current_user();
-		$post_id        = $request->get_header( 'X-WP-Post-ID' );
+		$post_id        = absint( $request->get_header( 'X-WP-Post-ID' ) );
 
 		if ( $logged_in_user ) {
 			$email         = $logged_in_user->user_email;

--- a/includes/class-singlepost-subscription.php
+++ b/includes/class-singlepost-subscription.php
@@ -34,6 +34,12 @@ class SinglePost_Subscription {
 		 * the inline gate, the overlay gate, Campaigns prompt suppression, and
 		 * the article_view activity suppression. Priority 20 runs after
 		 * Content_Restriction_Control (10) has computed the gate outcome.
+		 *
+		 * Newspack's Newsletters_Access shares priority 20. The order between
+		 * them does not matter because both only ever relax the predicate
+		 * (true to false) and never tighten it. A future callback at 20 that
+		 * tightens would make the outcome order-dependent, so anything added
+		 * here must preserve that relax-only invariant.
 		 */
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'maybe_unrestrict_unlocked_post' ], 20, 2 );
 

--- a/includes/class-singlepost-subscription.php
+++ b/includes/class-singlepost-subscription.php
@@ -44,6 +44,16 @@ class SinglePost_Subscription {
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'maybe_unrestrict_unlocked_post' ], 20, 2 );
 
 		/*
+		 * Access Control truncates gated posts in feeds whenever its
+		 * restrict_feeds setting is on, and that setting defaults to on. Google
+		 * News has to ingest the full article for Extended Access to ever be
+		 * offered on it, so feeds are exempted here for the same reason the Woo
+		 * Memberships path disables wc_memberships_is_feed_restricted in
+		 * WooCommerce::init().
+		 */
+		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'unrestrict_feed_content' ], 20, 2 );
+
+		/*
 		 * The metering short-circuit is still needed on top of the predicate:
 		 * surfaces such as the metering countdown call Metering::is_metering()
 		 * before checking the predicate, and that call records the view against
@@ -88,6 +98,33 @@ class SinglePost_Subscription {
 			return $is_post_restricted;
 		}
 		if ( self::has_valid_unlock( $post_id ) ) {
+			return false;
+		}
+		return $is_post_restricted;
+	}
+
+	/**
+	 * Gated posts are not restricted inside feeds, so their full body stays
+	 * available for Google News to ingest. Ingestion is a prerequisite for
+	 * Extended Access ever being offered on the article, so this takes
+	 * precedence over the Access Control restrict_feeds setting, exactly as the
+	 * Woo Memberships path takes precedence over that plugin's feed
+	 * restriction.
+	 *
+	 * @param bool $is_post_restricted Whether the post is restricted for the current user.
+	 * @param int  $post_id            Post ID.
+	 * @return bool
+	 */
+	public static function unrestrict_feed_content( $is_post_restricted, $post_id ) {
+		if ( ! $is_post_restricted ) {
+			return $is_post_restricted;
+		}
+		// While Woo Memberships is loaded it owns the front-end, and its own
+		// feed stand-down already covers this.
+		if ( DependencyChecker::is_wc_memberships_loaded() ) {
+			return $is_post_restricted;
+		}
+		if ( is_feed() ) {
 			return false;
 		}
 		return $is_post_restricted;

--- a/includes/class-singlepost-subscription.php
+++ b/includes/class-singlepost-subscription.php
@@ -25,11 +25,24 @@ class SinglePost_Subscription {
 		add_action( 'wp', [ __CLASS__, 'manage_paywall_restriction' ], 5 ); // Before Woo Memberships' restriction handler, which was lowered to 9 in 1.27.2.
 
 		/*
-		 * Newspack Access Control (content gates) integration. These filters are
-		 * only consulted by the first-party gating, which stands down while Woo
-		 * Memberships is active - so they are safe to register unconditionally.
+		 * Newspack Access Control (content gates) integration. Both callbacks
+		 * stand down while Woo Memberships is loaded, keeping the legacy path
+		 * untouched.
+		 *
+		 * The restriction predicate itself is filtered - rather than any single
+		 * rendering surface - because every Access Control surface keys off it:
+		 * the inline gate, the overlay gate, Campaigns prompt suppression, and
+		 * the article_view activity suppression. Priority 20 runs after
+		 * Content_Restriction_Control (10) has computed the gate outcome.
 		 */
-		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'maybe_allow_unlocked_post' ], 5, 2 ); // Before Access Control's metering handler at 10, so an unlocked view does not consume a metered view.
+		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'maybe_unrestrict_unlocked_post' ], 20, 2 );
+
+		/*
+		 * The metering short-circuit is still needed on top of the predicate:
+		 * surfaces such as the metering countdown call Metering::is_metering()
+		 * before checking the predicate, and that call records the view against
+		 * the reader's meter as a side effect.
+		 */
 		add_filter( 'newspack_content_gate_metering_short_circuit', [ __CLASS__, 'maybe_short_circuit_metering' ] );
 	}
 
@@ -52,21 +65,26 @@ class SinglePost_Subscription {
 	}
 
 	/**
-	 * Lift the Access Control restriction for a post the reader has unlocked
-	 * via Google Extended Access.
+	 * A post the reader has unlocked via Google Extended Access is not
+	 * restricted for them under Access Control.
 	 *
-	 * @param bool $restrict Whether to restrict the post.
-	 * @param int  $post_id  Post ID.
+	 * @param bool $is_post_restricted Whether the post is restricted for the current user.
+	 * @param int  $post_id            Post ID.
 	 * @return bool
 	 */
-	public static function maybe_allow_unlocked_post( $restrict, $post_id ) {
-		if ( ! $restrict ) {
-			return $restrict;
+	public static function maybe_unrestrict_unlocked_post( $is_post_restricted, $post_id ) {
+		if ( ! $is_post_restricted ) {
+			return $is_post_restricted;
+		}
+		// While Woo Memberships is loaded it owns the front-end; leave its
+		// restriction outcome untouched.
+		if ( DependencyChecker::is_wc_memberships_loaded() ) {
+			return $is_post_restricted;
 		}
 		if ( self::has_valid_unlock( $post_id ) ) {
 			return false;
 		}
-		return $restrict;
+		return $is_post_restricted;
 	}
 
 	/**
@@ -81,9 +99,9 @@ class SinglePost_Subscription {
 		if ( null !== $short_circuit ) {
 			return $short_circuit;
 		}
-		// While Woo Memberships is active it owns the front-end; leave its
+		// While Woo Memberships is loaded it owns the front-end; leave its
 		// metering interplay untouched.
-		if ( function_exists( 'wc_memberships' ) ) {
+		if ( DependencyChecker::is_wc_memberships_loaded() ) {
 			return $short_circuit;
 		}
 		if ( is_singular() && self::has_valid_unlock( get_queried_object_id() ) ) {
@@ -98,7 +116,7 @@ class SinglePost_Subscription {
 	public static function manage_paywall_restriction() {
 		// Woo Memberships-specific handling; under Newspack Access Control the
 		// integration happens via the content gate filters instead.
-		if ( ! function_exists( 'wc_memberships' ) ) {
+		if ( ! DependencyChecker::is_wc_memberships_loaded() ) {
 			return;
 		}
 

--- a/includes/class-singlepost-subscription.php
+++ b/includes/class-singlepost-subscription.php
@@ -23,12 +23,85 @@ class SinglePost_Subscription {
 		 * restrict access to post content.
 		 */
 		add_action( 'wp', [ __CLASS__, 'manage_paywall_restriction' ], 5 ); // Before Woo Memberships' restriction handler, which was lowered to 9 in 1.27.2.
+
+		/*
+		 * Newspack Access Control (content gates) integration. These filters are
+		 * only consulted by the first-party gating, which stands down while Woo
+		 * Memberships is active - so they are safe to register unconditionally.
+		 */
+		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'maybe_allow_unlocked_post' ], 5, 2 ); // Before Access Control's metering handler at 10, so an unlocked view does not consume a metered view.
+		add_filter( 'newspack_content_gate_metering_short_circuit', [ __CLASS__, 'maybe_short_circuit_metering' ] );
+	}
+
+	/**
+	 * Whether the current reader holds a valid unlock for the post.
+	 *
+	 * Only logged-in users can hold an unlock: the cookie name is keyed on
+	 * the post and user IDs (see REST_Controller::get_unlock_cookie_name()),
+	 * so a cookie minted for another post or user never matches.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return bool
+	 */
+	public static function has_valid_unlock( $post_id ) {
+		$user_id = get_current_user_id();
+		if ( ! $user_id || ! $post_id ) {
+			return false;
+		}
+		return isset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $post_id, $user_id ) ] );
+	}
+
+	/**
+	 * Lift the Access Control restriction for a post the reader has unlocked
+	 * via Google Extended Access.
+	 *
+	 * @param bool $restrict Whether to restrict the post.
+	 * @param int  $post_id  Post ID.
+	 * @return bool
+	 */
+	public static function maybe_allow_unlocked_post( $restrict, $post_id ) {
+		if ( ! $restrict ) {
+			return $restrict;
+		}
+		if ( self::has_valid_unlock( $post_id ) ) {
+			return false;
+		}
+		return $restrict;
+	}
+
+	/**
+	 * Skip Access Control metering entirely for an unlocked view, so the view
+	 * is neither counted against the reader's meter nor surfaced in metering
+	 * UI (e.g. the countdown notice).
+	 *
+	 * @param mixed $short_circuit Short-circuit value; anything non-null skips metering.
+	 * @return mixed
+	 */
+	public static function maybe_short_circuit_metering( $short_circuit ) {
+		if ( null !== $short_circuit ) {
+			return $short_circuit;
+		}
+		// While Woo Memberships is active it owns the front-end; leave its
+		// metering interplay untouched.
+		if ( function_exists( 'wc_memberships' ) ) {
+			return $short_circuit;
+		}
+		if ( is_singular() && self::has_valid_unlock( get_queried_object_id() ) ) {
+			return true;
+		}
+		return $short_circuit;
 	}
 
 	/**
 	 * Manages actions added by woocommerce membership to restrict access to post content.
 	 */
 	public static function manage_paywall_restriction() {
+		// Woo Memberships-specific handling; under Newspack Access Control the
+		// integration happens via the content gate filters instead.
+		if ( ! function_exists( 'wc_memberships' ) ) {
+			return;
+		}
+
 		$post_id = get_the_ID();
 		$user_id = get_current_user_id();
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,9 +10,21 @@
       <directory suffix=".php">./vendor</directory>
     </exclude>
   </coverage>
+  <!--
+    The Access Control integration tests are a separate suite because they
+    define the NEWSPACK_CONTENT_GATES constant, which cannot be undefined and
+    would otherwise leak into any test class running after them. Suite order
+    below guarantees they run last within a single phpunit invocation; the
+    `composer test` script runs each suite as its own process for full
+    isolation.
+  -->
   <testsuites>
     <testsuite name="Newspack Test Suite">
       <directory prefix="test-" suffix=".php">./tests/unit-tests</directory>
+      <exclude>./tests/unit-tests/test-integration-access-control.php</exclude>
+    </testsuite>
+    <testsuite name="Access Control Integration">
+      <file>./tests/unit-tests/test-integration-access-control.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -23,10 +23,14 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 	 * Setup for the tests.
 	 */
 	public static function set_up_before_class() {
-		// Install and activate Dependency Plugins.
-		$newspack_rel_latest = 'https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip';
+		// Install and activate Dependency Plugins. The Newspack plugin release
+		// is pinned so the harness does not float with `releases/latest`; a
+		// previously downloaded copy in the test WP install takes precedence
+		// (Plugin_Manager::install skips existing directories), so delete it
+		// when bumping the pin.
+		$newspack_release_zip = 'https://github.com/Automattic/newspack-plugin/releases/download/v6.42.3/newspack-plugin.zip';
 		echo esc_html( 'Installing Newspack...' . PHP_EOL );
-		\Newspack\ExtendedAccess\Plugin_Manager::install( $newspack_rel_latest );
+		\Newspack\ExtendedAccess\Plugin_Manager::install( $newspack_release_zip );
 
 		echo esc_html( 'Activating Newspack...' . PHP_EOL );
 		\Newspack\ExtendedAccess\Plugin_Manager::activate( 'newspack-plugin' );

--- a/tests/unit-tests/test-google-jwt.php
+++ b/tests/unit-tests/test-google-jwt.php
@@ -38,7 +38,7 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 		$private_key = openssl_pkey_new(
 			array(
 				'digest_alg'       => 'sha256',
-				'private_key_bits' => 1024,
+				'private_key_bits' => 2048,
 				'private_key_type' => OPENSSL_KEYTYPE_RSA,
 			)
 		);
@@ -100,7 +100,7 @@ class Newspack_Test_Google_JWT extends WP_UnitTestCase {
 		$private_key = openssl_pkey_new(
 			array(
 				'digest_alg'       => 'sha256',
-				'private_key_bits' => 1024,
+				'private_key_bits' => 2048,
 				'private_key_type' => OPENSSL_KEYTYPE_RSA,
 			)
 		);

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -16,8 +16,30 @@ require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
 /**
  * Tests that unlocks granted via Google Extended Access are honored by the
  * first-party Newspack Access Control gating (WooCommerce Memberships inactive).
+ *
+ * This class defines the NEWSPACK_CONTENT_GATES constant, which cannot be
+ * undefined again, so it lives in its own phpunit testsuite ("Access Control
+ * Integration") that is ordered last in phpunit.xml - and `composer test`
+ * runs it as a separate phpunit process for full isolation. Any future test
+ * that asserts flag-off behavior must not share a process with this suite.
+ * (PHPUnit's run-class-in-separate-process mode is not usable here: the
+ * re-executed WP tests bootstrap hangs on install.php against the parent's
+ * open DB connections. Its annotation must also never be spelled with the
+ * at-sign in this docblock - PHPUnit parses it from prose.)
  */
 class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
+
+	/**
+	 * The Newspack plugin release the suite is verified against. Pinned so the
+	 * harness does not float with `releases/latest` (a moving target that can
+	 * silently change what these tests exercise). Note Plugin_Manager::install
+	 * skips the download when a newspack-plugin directory already exists in
+	 * the test WP install, so a stale copy must be deleted for a new pin to
+	 * take effect.
+	 *
+	 * @var string
+	 */
+	const NEWSPACK_PLUGIN_ZIP = 'https://github.com/Automattic/newspack-plugin/releases/download/v6.42.3/newspack-plugin.zip';
 
 	/**
 	 * Sample post ID.
@@ -38,9 +60,12 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	 */
 	public static function set_up_before_class() {
 		// Install and activate the Newspack plugin (no-ops when already present).
-		$newspack_rel_latest = 'https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip';
-		\Newspack\ExtendedAccess\Plugin_Manager::install( $newspack_rel_latest );
+		\Newspack\ExtendedAccess\Plugin_Manager::install( self::NEWSPACK_PLUGIN_ZIP );
 		\Newspack\ExtendedAccess\Plugin_Manager::activate( 'newspack-plugin' );
+
+		// The plugin loaded after the bootstrap fired 'init'; fire it again so
+		// init-dependent registrations (e.g. default access rules) run.
+		do_action( 'init' );
 
 		// Enable the Access Control feature flag. Content_Gate re-reads the
 		// constant on every call when IS_TEST_ENV is defined.
@@ -62,13 +87,17 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Remove any unlock cookies set by a test.
+	 * Remove unlock cookies and gates set by a test.
 	 */
 	public function tear_down() {
 		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id ) ] );
 		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id + 1 ) ] );
 		// phpcs:enable
+		foreach ( \Newspack\Content_Gate::get_gates() as $gate ) {
+			wp_delete_post( $gate['id'], true );
+		}
+		$this->reset_post_gates_cache();
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
@@ -85,25 +114,117 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Clear Content_Restriction_Control request-scoped caches, so gates
+	 * created mid-test become visible to restriction checks.
+	 */
+	private function reset_post_gates_cache() {
+		// Not all cache properties exist in every Newspack plugin release;
+		// reset whichever this one has.
+		foreach ( array( 'post_gates_map', 'post_gate_id_map', 'post_gate_layout_id_map' ) as $property_name ) {
+			if ( ! property_exists( \Newspack\Content_Restriction_Control::class, $property_name ) ) {
+				continue;
+			}
+			$cache_property = new ReflectionProperty( \Newspack\Content_Restriction_Control::class, $property_name );
+			$cache_property->setAccessible( true );
+			$cache_property->setValue( null, array() );
+		}
+	}
+
+	/**
+	 * Create a published paywall-style gate applying to all posts, which the
+	 * test reader fails (email domain whitelist).
+	 *
+	 * @param array $layout_meta Optional meta to set on the gate layout post (e.g. overlay style).
+	 * @return int Gate ID.
+	 */
+	private function create_failing_paywall_gate( $layout_meta = array() ) {
+		$paywall_gate_id = \Newspack\Content_Gate::create_gate( array( 'title' => 'EA Paywall Gate' ) );
+		\Newspack\Content_Gate::update_gate_settings(
+			$paywall_gate_id,
+			array(
+				'title'         => 'EA Paywall Gate',
+				'status'        => 'publish',
+				'priority'      => 1,
+				'content_rules' => array(
+					array(
+						'slug'  => 'post_types',
+						'value' => array( 'post' ),
+					),
+				),
+				'registration'  => array(
+					'active'               => false,
+					'metering'             => array(
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					),
+					'require_verification' => false,
+					'gate_id'              => 0,
+				),
+				'custom_access' => array(
+					'active'       => true,
+					'metering'     => array(
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					),
+					'gate_id'      => 0,
+					'access_rules' => array(
+						array(
+							'slug'  => 'email_domain',
+							'value' => 'vip.example.com',
+						),
+					),
+				),
+			)
+		);
+		if ( ! empty( $layout_meta ) ) {
+			// Gate layouts are separate posts, auto-created by
+			// update_gate_settings() and referenced from the settings meta;
+			// apply layout meta (e.g. overlay style) to each of them, falling
+			// back to the gate post itself for releases without layout posts.
+			$layout_ids = array();
+			foreach ( array( 'registration', 'custom_access' ) as $settings_key ) {
+				$settings = get_post_meta( $paywall_gate_id, $settings_key, true );
+				if ( is_array( $settings ) && ! empty( $settings['gate_layout_id'] ) ) {
+					$layout_ids[] = (int) $settings['gate_layout_id'];
+				}
+			}
+			if ( empty( $layout_ids ) ) {
+				$layout_ids[] = $paywall_gate_id;
+			}
+			foreach ( array_unique( $layout_ids ) as $layout_id ) {
+				foreach ( $layout_meta as $meta_key => $meta_value ) {
+					update_post_meta( $layout_id, $meta_key, $meta_value );
+				}
+			}
+		}
+		$this->reset_post_gates_cache();
+		return $paywall_gate_id;
+	}
+
+	/**
 	 * Without WooCommerce Memberships active, the legacy restriction handler
 	 * must be a no-op instead of a fatal.
 	 */
 	public function test_no_fatal_without_woocommerce_memberships() {
-		$this->assertFalse( function_exists( 'wc_memberships' ), 'Precondition: WCM is not loaded in this suite.' );
+		$this->assertFalse( DependencyChecker::is_wc_memberships_loaded(), 'Precondition: WCM is not loaded in this suite.' );
 		SinglePost_Subscription::manage_paywall_restriction();
 		$this->assertTrue( true, 'manage_paywall_restriction() did not fatal without WCM.' );
 	}
 
 	/**
-	 * A logged-in reader with a valid unlock cookie has the Access Control
-	 * restriction lifted for that post.
+	 * A logged-in reader with a valid unlock cookie is not restricted: the
+	 * restriction predicate itself is lifted, which opens every Access Control
+	 * surface that keys off it (inline gate, overlay gate, prompt suppression,
+	 * article_view activity suppression).
 	 */
-	public function test_unlock_cookie_allows_post_under_access_control() {
+	public function test_unlock_cookie_lifts_restriction_predicate() {
 		wp_set_current_user( $this->reader_id );
 		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
 		$this->assertFalse(
-			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
-			'A valid unlock cookie must lift the restriction.'
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
+			'A valid unlock cookie must lift the restriction predicate.'
 		);
 	}
 
@@ -113,7 +234,7 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	public function test_no_cookie_stays_restricted() {
 		wp_set_current_user( $this->reader_id );
 		$this->assertTrue(
-			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
 			'Without an unlock cookie the restriction must hold.'
 		);
 	}
@@ -126,7 +247,7 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		$other_post_id = $this->factory->post->create();
 		$this->set_unlock_cookie( $other_post_id, $this->reader_id );
 		$this->assertTrue(
-			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
 			'An unlock for another post must not unlock this post.'
 		);
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
@@ -141,7 +262,7 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		wp_set_current_user( $this->reader_id );
 		$this->set_unlock_cookie( $this->post_id, $this->reader_id + 1 );
 		$this->assertTrue(
-			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
 			'An unlock minted for another user must not unlock the post.'
 		);
 	}
@@ -153,11 +274,81 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 		$this->set_unlock_cookie( $this->post_id, 0 );
 		$this->assertTrue(
-			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
 			'Anonymous visitors must stay restricted.'
 		);
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, 0 ) ] );
+	}
+
+	/**
+	 * The overlay gate must not render over an unlocked post: it is an
+	 * independent rendering path from the inline gate, keying off the
+	 * restriction predicate.
+	 */
+	public function test_overlay_gate_not_rendered_for_unlocked_post() {
+		$this->create_failing_paywall_gate( array( 'style' => 'overlay' ) );
+		wp_set_current_user( $this->reader_id );
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		// With an unlock: predicate lifted, overlay must not render.
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
+		$this->assertFalse( \Newspack\Content_Gate::is_post_restricted( $this->post_id ), 'Precondition: the unlock lifts the restriction.' );
+		ob_start();
+		\Newspack\Content_Gate::render_overlay_gate();
+		$overlay_output_unlocked = ob_get_clean();
+		$this->assertStringNotContainsString(
+			'newspack-content-gate__overlay-gate',
+			$overlay_output_unlocked,
+			'The overlay gate must not render over an unlocked post.'
+		);
+
+		// Without the unlock: reader is restricted and the overlay renders.
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id ) ] );
+		$this->assertTrue( \Newspack\Content_Gate::is_post_restricted( $this->post_id ), 'Precondition: the reader fails the paywall rule.' );
+		ob_start();
+		\Newspack\Content_Gate::render_overlay_gate();
+		$overlay_output_locked = ob_get_clean();
+		$this->assertStringContainsString(
+			'newspack-content-gate__overlay-gate',
+			$overlay_output_locked,
+			'The overlay gate renders for a locked reader (control).'
+		);
+	}
+
+	/**
+	 * Campaigns prompts are not suppressed and the article_view reader
+	 * activity is not dropped on an unlocked view.
+	 */
+	public function test_popups_and_article_view_not_suppressed_for_unlocked_post() {
+		$this->create_failing_paywall_gate();
+		wp_set_current_user( $this->reader_id );
+		$this->go_to( get_permalink( $this->post_id ) );
+		$article_view_activity = array( 'action' => 'article_view' );
+
+		// Control: on a locked view both surfaces suppress.
+		\Newspack\Content_Gate::is_post_restricted( $this->post_id ); // Warm the gate map, as restrict_post() does on a real request.
+		$this->assertTrue(
+			apply_filters( 'newspack_popups_assess_has_disabled_popups', false ),
+			'Prompts are suppressed on a locked view (control).'
+		);
+		$this->assertFalse(
+			apply_filters( 'newspack_reader_activity_article_view', $article_view_activity ),
+			'The article_view activity is dropped on a locked view (control).'
+		);
+
+		// With the unlock: neither surface suppresses.
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
+		$this->assertFalse(
+			apply_filters( 'newspack_popups_assess_has_disabled_popups', false ),
+			'Prompts must not be suppressed on an unlocked view.'
+		);
+		$this->assertSame(
+			$article_view_activity,
+			apply_filters( 'newspack_reader_activity_article_view', $article_view_activity ),
+			'The article_view activity must not be dropped on an unlocked view.'
+		);
 	}
 
 	/**
@@ -183,6 +374,45 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		$this->assertNull(
 			apply_filters( 'newspack_content_gate_metering_short_circuit', null ),
 			'Metering must not be short-circuited without an unlock.'
+		);
+	}
+
+	/**
+	 * The unlock-article endpoint reports a metered unlock as UNLOCKED, not
+	 * SUBSCRIBER: holding an unlock cookie is not full gate access.
+	 */
+	public function test_unlock_article_reports_unlocked_not_subscriber() {
+		$this->create_failing_paywall_gate();
+		wp_set_current_user( $this->reader_id );
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
+
+		$unlock_request = new WP_REST_Request( 'POST', '/newspack-extended-access/v1/unlock-article' );
+		$unlock_request->set_header( 'X-WP-Post-ID', (string) $this->post_id );
+		$unlock_response = REST_Controller::api_unlock_article( $unlock_request );
+
+		$this->assertSame(
+			'UNLOCKED',
+			$unlock_response->get_data()['status'],
+			'A reader whose only access is the unlock must be reported as UNLOCKED (metering grant), not SUBSCRIBER.'
+		);
+	}
+
+	/**
+	 * The unlock-article endpoint reports SUBSCRIBER for a reader with actual
+	 * gate access (no gates restrict them).
+	 */
+	public function test_unlock_article_reports_subscriber_with_gate_access() {
+		// No gates: the reader has full access to the post.
+		wp_set_current_user( $this->reader_id );
+
+		$unlock_request = new WP_REST_Request( 'POST', '/newspack-extended-access/v1/unlock-article' );
+		$unlock_request->set_header( 'X-WP-Post-ID', (string) $this->post_id );
+		$unlock_response = REST_Controller::api_unlock_article( $unlock_request );
+
+		$this->assertSame(
+			'SUBSCRIBER',
+			$unlock_response->get_data()['status'],
+			'A reader with full access must be reported as SUBSCRIBER.'
 		);
 	}
 

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -92,11 +92,16 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	public function tear_down() {
 		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id ) ] );
-		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id + 1 ) ] );
 		// phpcs:enable
 		foreach ( \Newspack\Content_Gate::get_gates() as $gate ) {
 			wp_delete_post( $gate['id'], true );
 		}
+		// The stand-in for the Access Control implementation names a method the
+		// pinned Newspack release does not have, so a test that leaves it
+		// registered would fatal any later test that fires the filter. Removing
+		// it here rather than inline keeps that true even when a test fails
+		// partway through.
+		remove_filter( 'newspack_post_has_restrictions', DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK );
 		$this->reset_post_gates_cache();
 		wp_set_current_user( 0 );
 		parent::tear_down();
@@ -209,8 +214,16 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	 */
 	public function test_no_fatal_without_woocommerce_memberships() {
 		$this->assertFalse( DependencyChecker::is_wc_memberships_loaded(), 'Precondition: WCM is not loaded in this suite.' );
+
 		SinglePost_Subscription::manage_paywall_restriction();
-		$this->assertTrue( true, 'manage_paywall_restriction() did not fatal without WCM.' );
+
+		// The handler's whole job under Access Control is to do nothing, so the
+		// observable outcome is that it removed no Woo Memberships hook and
+		// reaching this line at all means it did not fatal.
+		$this->assertFalse(
+			has_action( 'the_content', 'wc_memberships_the_content' ),
+			'No Woo Memberships content handler may be left registered when WCM is inactive.'
+		);
 	}
 
 	/**
@@ -259,12 +272,17 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	 * for the current user.
 	 */
 	public function test_cookie_for_other_user_stays_restricted() {
+		$other_reader_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		wp_set_current_user( $this->reader_id );
-		$this->set_unlock_cookie( $this->post_id, $this->reader_id + 1 );
+
+		$this->set_unlock_cookie( $this->post_id, $other_reader_id );
+
 		$this->assertTrue(
 			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
 			'An unlock minted for another user must not unlock the post.'
 		);
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $other_reader_id ) ] );
 	}
 
 	/**
@@ -395,6 +413,14 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 			$unlock_response->get_data()['status'],
 			'A reader whose only access is the unlock must be reported as UNLOCKED (metering grant), not SUBSCRIBER.'
 		);
+		// The gate evaluation above detaches the unlock filter to avoid reading a
+		// metered unlock as full access. Leaving it detached would silently stop
+		// lifting restrictions for the rest of the request, and set_up() re-runs
+		// init() for every test, so nothing else here would notice.
+		$this->assertNotFalse(
+			has_filter( 'newspack_is_post_restricted', [ SinglePost_Subscription::class, 'maybe_unrestrict_unlocked_post' ] ),
+			'The unlock filter must be restored after the gate access check.'
+		);
 	}
 
 	/**
@@ -500,6 +526,39 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		$this->assertFalse(
 			DependencyChecker::is_newspack_restriction_state_available(),
 			'The restriction state stops being knowable when the implementation goes away.'
+		);
+	}
+
+	/**
+	 * The callback name is a cross-repo contract: if the Newspack plugin ever
+	 * renames or relocates its implementation, this plugin goes permanently
+	 * quiet with no other symptom. The test above cannot catch that - it
+	 * registers the same constant it then looks for - so assert the constant
+	 * against the real class.
+	 *
+	 * Skips while the pinned Newspack release predates the implementation, and
+	 * starts asserting the moment that pin moves past it.
+	 */
+	public function test_restriction_callback_constant_matches_the_newspack_implementation() {
+		list( $class_name, $method_name ) = DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK;
+
+		if ( ! method_exists( $class_name, $method_name ) ) {
+			$this->markTestSkipped(
+				sprintf(
+					'The pinned Newspack release has no %s::%s(). Once the pin moves past the content-gate implementation, this test asserts the contract instead of skipping.',
+					$class_name,
+					$method_name
+				)
+			);
+		}
+
+		$this->assertTrue(
+			is_callable( DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK ),
+			'The pinned callback must name a real, callable Newspack implementation.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'newspack_post_has_restrictions', DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK ),
+			'The Newspack implementation must be registered under the exact callback identity this plugin looks for.'
 		);
 	}
 

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -452,34 +452,91 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The LD+JSON schema is emitted under Access Control, with
-	 * isAccessibleForFree reflecting the post's gating.
+	 * The LD+JSON schema reports a gated post as not accessible for free.
 	 */
-	public function test_ld_json_under_access_control() {
+	public function test_ld_json_marks_gated_post_as_not_free() {
 		$this->go_to( get_permalink( $this->post_id ) );
 
-		// Simulate a post covered by a content gate.
-		add_filter( 'newspack_post_has_restrictions', '__return_true' );
 		ob_start();
-		Google_ExtendedAccess::add_extended_access_ld_json();
+		Google_ExtendedAccess::render_extended_access_ld_json( true );
 		$output = ob_get_clean();
-		remove_filter( 'newspack_post_has_restrictions', '__return_true' );
 
-		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted under Access Control.' );
+		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted.' );
 		$this->assertStringContainsString( '"isAccessibleForFree":false', $output, 'A gated post must be marked not accessible for free.' );
 	}
 
 	/**
 	 * The LD+JSON schema marks ungated posts as accessible for free.
 	 */
-	public function test_ld_json_ungated_post_is_free() {
+	public function test_ld_json_marks_ungated_post_as_free() {
 		$this->go_to( get_permalink( $this->post_id ) );
+
+		ob_start();
+		Google_ExtendedAccess::render_extended_access_ld_json( false );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted.' );
+		$this->assertStringContainsString( '"isAccessibleForFree":true', $output, 'An ungated post must be marked accessible for free.' );
+	}
+
+	/**
+	 * The restriction state becomes knowable as soon as the Access Control
+	 * implementation registers on the filter.
+	 *
+	 * Only the predicate is exercised: the stand-in callback names a method
+	 * the pinned Newspack release does not carry, so firing the filter would
+	 * fatal. What the predicate reads is the registration, not the result.
+	 */
+	public function test_restriction_state_available_once_access_control_implements_the_filter() {
+		add_filter( 'newspack_post_has_restrictions', DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK );
+
+		$this->assertTrue(
+			DependencyChecker::is_newspack_restriction_state_available(),
+			'The restriction state is knowable once the Access Control implementation is registered.'
+		);
+
+		remove_filter( 'newspack_post_has_restrictions', DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK );
+
+		$this->assertFalse(
+			DependencyChecker::is_newspack_restriction_state_available(),
+			'The restriction state stops being knowable when the implementation goes away.'
+		);
+	}
+
+	/**
+	 * `Content_Gate::post_has_restrictions()` returns a filtered default of
+	 * false, so a Newspack build that does not yet answer
+	 * `newspack_post_has_restrictions` for content gates reports every post as
+	 * ungated. Emitting the schema off that default would tell Google that
+	 * gated articles are free, so no schema is emitted until the Access
+	 * Control implementation is present. This decouples the plugin's release
+	 * from the Newspack plugin's: EA may be deployed to an Access Control site
+	 * ahead of the implementation without mislabeling gated content.
+	 *
+	 * The pinned Newspack release predates that implementation, so this test
+	 * exercises the real "too early" state rather than a simulated one.
+	 */
+	public function test_ld_json_skipped_when_restriction_state_is_unknowable() {
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		$this->assertNotFalse(
+			has_filter( 'newspack_post_has_restrictions' ),
+			'Guards the reason the check is by name: Woo Memberships registers on this filter even with Memberships inactive, so a bare has_filter() would wrongly report the state as knowable.'
+		);
+		$this->assertFalse(
+			has_filter( 'newspack_post_has_restrictions', DependencyChecker::NEWSPACK_POST_HAS_RESTRICTIONS_CALLBACK ),
+			'Guards the premise: the pinned Newspack release must not carry the Access Control implementation, or this test proves nothing.'
+		);
+		$this->assertFalse(
+			DependencyChecker::is_newspack_restriction_state_available(),
+			'The restriction state is not knowable without the Access Control implementation of the filter.'
+		);
 
 		ob_start();
 		Google_ExtendedAccess::add_extended_access_ld_json();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted under Access Control.' );
-		$this->assertStringContainsString( '"isAccessibleForFree":true', $output, 'An ungated post must be marked accessible for free.' );
+		$this->assertStringNotContainsString( 'newspack-extended-access-schema', $output, 'No schema may be emitted when the restriction state is unknowable.' );
 	}
+
 }

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -396,6 +396,32 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A gated post is not restricted inside a feed, so Google News can ingest
+	 * the full article. Without this, Access Control's restrict_feeds setting -
+	 * which is on by default - truncates the body to the gate excerpt and the
+	 * article stops being eligible for Extended Access entirely.
+	 */
+	public function test_gated_post_is_unrestricted_in_feeds() {
+		wp_set_current_user( 0 );
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', true, $this->post_id ),
+			'Outside a feed the gated post stays restricted.'
+		);
+
+		global $wp_query;
+		$was_feed          = $wp_query->is_feed;
+		$wp_query->is_feed = true;
+		$restricted_in_feed = apply_filters( 'newspack_is_post_restricted', true, $this->post_id );
+		$wp_query->is_feed = $was_feed;
+
+		$this->assertFalse(
+			$restricted_in_feed,
+			'A gated post must not be restricted inside a feed, or Google News cannot ingest it.'
+		);
+	}
+
+	/**
 	 * The unlock-article endpoint reports a metered unlock as UNLOCKED, not
 	 * SUBSCRIBER: holding an unlock cookie is not full gate access.
 	 */

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Tests the Newspack Access Control (content gates) integration.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\ExtendedAccess\DependencyChecker;
+use Newspack\ExtendedAccess\Google_ExtendedAccess;
+use Newspack\ExtendedAccess\Initializer;
+use Newspack\ExtendedAccess\REST_Controller;
+use Newspack\ExtendedAccess\SinglePost_Subscription;
+
+require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
+
+/**
+ * Tests that unlocks granted via Google Extended Access are honored by the
+ * first-party Newspack Access Control gating (WooCommerce Memberships inactive).
+ */
+class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
+
+	/**
+	 * Sample post ID.
+	 *
+	 * @var int
+	 */
+	protected $post_id;
+
+	/**
+	 * Sample reader user ID.
+	 *
+	 * @var int
+	 */
+	protected $reader_id;
+
+	/**
+	 * Load the Newspack plugin, which provides the Access Control system.
+	 */
+	public static function set_up_before_class() {
+		// Install and activate the Newspack plugin (no-ops when already present).
+		$newspack_rel_latest = 'https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip';
+		\Newspack\ExtendedAccess\Plugin_Manager::install( $newspack_rel_latest );
+		\Newspack\ExtendedAccess\Plugin_Manager::activate( 'newspack-plugin' );
+
+		// Enable the Access Control feature flag. Content_Gate re-reads the
+		// constant on every call when IS_TEST_ENV is defined.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Setup for the tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		SinglePost_Subscription::init();
+
+		$this->post_id   = $this->factory->post->create();
+		$this->reader_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * Remove any unlock cookies set by a test.
+	 */
+	public function tear_down() {
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id ) ] );
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, $this->reader_id + 1 ) ] );
+		// phpcs:enable
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Set the unlock cookie for a post/user pair.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $user_id User ID.
+	 */
+	private function set_unlock_cookie( $post_id, $user_id ) {
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$_COOKIE[ REST_Controller::get_unlock_cookie_name( $post_id, $user_id ) ] = '1';
+	}
+
+	/**
+	 * Without WooCommerce Memberships active, the legacy restriction handler
+	 * must be a no-op instead of a fatal.
+	 */
+	public function test_no_fatal_without_woocommerce_memberships() {
+		$this->assertFalse( function_exists( 'wc_memberships' ), 'Precondition: WCM is not loaded in this suite.' );
+		SinglePost_Subscription::manage_paywall_restriction();
+		$this->assertTrue( true, 'manage_paywall_restriction() did not fatal without WCM.' );
+	}
+
+	/**
+	 * A logged-in reader with a valid unlock cookie has the Access Control
+	 * restriction lifted for that post.
+	 */
+	public function test_unlock_cookie_allows_post_under_access_control() {
+		wp_set_current_user( $this->reader_id );
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
+		$this->assertFalse(
+			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			'A valid unlock cookie must lift the restriction.'
+		);
+	}
+
+	/**
+	 * Without an unlock cookie the post stays restricted.
+	 */
+	public function test_no_cookie_stays_restricted() {
+		wp_set_current_user( $this->reader_id );
+		$this->assertTrue(
+			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			'Without an unlock cookie the restriction must hold.'
+		);
+	}
+
+	/**
+	 * An unlock cookie for a different post does not unlock this post.
+	 */
+	public function test_cookie_for_other_post_stays_restricted() {
+		wp_set_current_user( $this->reader_id );
+		$other_post_id = $this->factory->post->create();
+		$this->set_unlock_cookie( $other_post_id, $this->reader_id );
+		$this->assertTrue(
+			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			'An unlock for another post must not unlock this post.'
+		);
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $other_post_id, $this->reader_id ) ] );
+	}
+
+	/**
+	 * An unlock cookie minted for a different user does not unlock the post
+	 * for the current user.
+	 */
+	public function test_cookie_for_other_user_stays_restricted() {
+		wp_set_current_user( $this->reader_id );
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id + 1 );
+		$this->assertTrue(
+			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			'An unlock minted for another user must not unlock the post.'
+		);
+	}
+
+	/**
+	 * Anonymous visitors never get an unlock, even if a cookie is present.
+	 */
+	public function test_anonymous_with_cookie_stays_restricted() {
+		wp_set_current_user( 0 );
+		$this->set_unlock_cookie( $this->post_id, 0 );
+		$this->assertTrue(
+			apply_filters( 'newspack_content_gate_restrict_post', true, $this->post_id ),
+			'Anonymous visitors must stay restricted.'
+		);
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_COOKIE[ REST_Controller::get_unlock_cookie_name( $this->post_id, 0 ) ] );
+	}
+
+	/**
+	 * An unlocked view must not consume a metered view: the metering
+	 * short-circuit fires for the unlocked post.
+	 */
+	public function test_metering_short_circuit_with_unlock() {
+		wp_set_current_user( $this->reader_id );
+		$this->set_unlock_cookie( $this->post_id, $this->reader_id );
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertTrue(
+			apply_filters( 'newspack_content_gate_metering_short_circuit', null ),
+			'Metering must be short-circuited for an unlocked view.'
+		);
+	}
+
+	/**
+	 * Metering proceeds normally when there is no unlock.
+	 */
+	public function test_metering_not_short_circuited_without_unlock() {
+		wp_set_current_user( $this->reader_id );
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertNull(
+			apply_filters( 'newspack_content_gate_metering_short_circuit', null ),
+			'Metering must not be short-circuited without an unlock.'
+		);
+	}
+
+	/**
+	 * Access Control is detected as an available gating system.
+	 */
+	public function test_access_control_detected() {
+		$this->assertTrue(
+			DependencyChecker::is_newspack_access_control_active(),
+			'Access Control must be detected when Newspack is active and the feature flag is on.'
+		);
+	}
+
+	/**
+	 * On a site with Access Control (and no WCM), dependencies are valid as
+	 * long as the Google Client API ID is configured.
+	 */
+	public function test_dependencies_valid_with_access_control_only() {
+		update_option( 'newspack_extended_access__google_client_api_id', 'example.com' );
+		$this->assertTrue(
+			Initializer::has_valid_dependencies(),
+			'EA must consider dependencies valid on an Access Control site without WCM.'
+		);
+		delete_option( 'newspack_extended_access__google_client_api_id' );
+	}
+
+	/**
+	 * Without a Google Client API ID, dependencies are invalid even with
+	 * Access Control present.
+	 */
+	public function test_dependencies_invalid_without_google_client_id() {
+		delete_option( 'newspack_extended_access__google_client_api_id' );
+		$this->assertFalse(
+			Initializer::has_valid_dependencies(),
+			'The Google Client API ID requirement still applies under Access Control.'
+		);
+	}
+
+	/**
+	 * The LD+JSON schema is emitted under Access Control, with
+	 * isAccessibleForFree reflecting the post's gating.
+	 */
+	public function test_ld_json_under_access_control() {
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		// Simulate a post covered by a content gate.
+		add_filter( 'newspack_post_has_restrictions', '__return_true' );
+		ob_start();
+		Google_ExtendedAccess::add_extended_access_ld_json();
+		$output = ob_get_clean();
+		remove_filter( 'newspack_post_has_restrictions', '__return_true' );
+
+		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted under Access Control.' );
+		$this->assertStringContainsString( '"isAccessibleForFree":false', $output, 'A gated post must be marked not accessible for free.' );
+	}
+
+	/**
+	 * The LD+JSON schema marks ungated posts as accessible for free.
+	 */
+	public function test_ld_json_ungated_post_is_free() {
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		ob_start();
+		Google_ExtendedAccess::add_extended_access_ld_json();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'newspack-extended-access-schema', $output, 'The LD+JSON schema must be emitted under Access Control.' );
+		$this->assertStringContainsString( '"isAccessibleForFree":true', $output, 'An ungated post must be marked accessible for free.' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On a site migrated to Newspack Access Control (Woo Memberships deactivated), Extended Access previously went **silently dark**: the dependency checker refused to init, so no REST routes, no SwG scripts, and no `isAccessibleForFree` LD+JSON – Google would stop offering register-to-read unlocks entirely. This PR makes EA a first-class citizen of both gating systems:

- **Dependency checker**: EA now initializes with a Google client ID AND (the WCM stack OR Access Control active); dependent init is deferred to `plugins_loaded`. The missing-client-ID admin notice branches: WCM present → existing settings-tab link; AC-only → names the `newspack_extended_access__google_client_api_id` option and the exact WP-CLI command to set it. (#24, stacked on this, replaces that CLI instruction with a real settings page.)
- **Unlock honor under AC, at the predicate level**: a valid unlock cookie lifts `newspack_is_post_restricted` (priority 20, after the gate's own callbacks; stands down when WCM is loaded). Every AC surface consults this predicate – inline gate, overlay gate, Campaigns prompt suppression, `article_view` activity – so unlocked readers get the full normal-article experience. The metering short-circuit filter is also hooked so the unlocked view doesn't consume a metered view via the countdown's side-effecting check.
- **Feeds stay whole**: Access Control truncates gated posts in feeds whenever its `restrict_feeds` setting is on, and it defaults to on. Google News has to ingest the full article for Extended Access to ever be offered on it, so feeds are exempted from the restriction predicate – the Access Control counterpart of the long-standing `wc_memberships_is_feed_restricted` stand-down in `WooCommerce::init()`. Without this, migrating a WCM+EA site to Access Control would silently drop it out of Google News ingestion.
- **REST semantics**: access checks unified in `can_user_view_post()` – WCM branch unchanged; AC branch uses the gate predicate with the unlock filter removed/re-added around grant evaluation so a metered unlock reports `UNLOCKED`, not `SUBSCRIBER`. That removal/restore is exception-safe (`finally`), restores at the priority the filter was actually registered at, and is covered by an assertion that fails if the restoration is dropped. The AC branch `_doing_it_wrong()`s when the passed user differs from the current user rather than denying quietly. `X-WP-Post-ID` is absint-ed in all handlers.
- **Guards**: `wc_memberships()` is no longer reachable without WCM (single `DependencyChecker::is_wc_memberships_loaded()` predicate everywhere). The login destination is handed to the SwG script bare, and the script merges query args properly, so the live URL (and the Extended Access params on it) survives the login round trip – previously the script's appended `?redirect=` collided with a pre-set `redirect_to`, folding them together and losing `gaa_ts`, so the flow could not resume after login.
- **Tests/harness**: 21-test AC integration suite (unlock honored/scoped, wrong-post/wrong-user/anonymous still gated, feeds unrestricted, WCM path unchanged, no fatal without WCM, UNLOCKED-vs-SUBSCRIBER, filter restoration, prompts/activity parity with locked-state controls) in its own phpunit testsuite pinned last for constant isolation. `composer test` runs the suites as separate processes, and CI now uses it, so the isolation the config documents is the one that actually runs. The test-WP installer's newspack-plugin download is pinned (was floating on `releases/latest`, already stale-serving).

### Release ordering (please read before merging)

The `isAccessibleForFree` LD+JSON leg depends on Automattic/newspack-workspace#690, which implements the `newspack_post_has_restrictions` filter for content gates. Until that ships to a site's release channel:

- `Content_Gate::post_has_restrictions()` is a stub returning the filter's `false` default, which is indistinguishable from "this post is not gated".
- So this plugin **emits no schema at all** on Access Control sites rather than emitting a wrong one. Advertising every gated article as free is worse than staying quiet: that flag is exactly what Google reads to decide whether to run the entitlement flow.
- Everything else in this PR (unlock honoring, REST semantics, feeds) works against current `main` and does not wait on #690.

The check looks for the Access Control implementation **by callback name**, because the Woo Memberships integration registers on that same filter unconditionally and passes through when WCM is inactive – so a bare `has_filter()` is true on every site and proves nothing. A test asserts the constant against the real Newspack class, skipping while the pinned release predates the implementation and asserting the contract the moment that pin moves, so a rename cannot silently disable the schema forever.

The unlock cookie model is unchanged (name = salted `wp_hash(post_id|user_id)`, HttpOnly, checked for logged-in users only).

Known follow-ups deliberately out of scope, all filed: NPPD-2119 (Access Control should disable its `restrict_feeds` toggle with a note while EA overrides it), NPPD-2121 (a failed reader registration is reported to Google as granted – pre-existing), NPPD-2122 (unlock grants have no server-side expiry, cookie-value integrity, or post validation – pre-existing parity with the WCM path), NPPD-2123 (the gate memo and the metering short-circuit both ignore the unlock), NPPD-2104 (settings surface – PR #24, stacked on this), NPPD-2105 (the pre-existing broken JWT test fixture and the repo-wide PHPCS toolchain).

Closes NPPD-1901.

### How to test:

1. Env with newspack-plugin (`NEWSPACK_CONTENT_GATES` on, RAS on), EA active, **no Woo Memberships**; set the Google client ID option via WP-CLI; configure a metered gate.
2. A gated article renders the gate. With #690 also present it emits `"isAccessibleForFree":false`; without it, no schema is emitted at all (expected – see Release ordering). With `gaa_*` URL params the full SwG stack loads.
3. As a logged-in reader with an exhausted meter, mint an unlock (POST `/newspack-extended-access/v1/unlock-article` with the article's `X-WP-Post-ID`) – the article opens fully (inline AND overlay gate layouts), prompts and `article_view` activity behave as on any open article, and the meter is not decremented.
4. Remove the cookie – gated again; the cookie does not unlock other posts or other users.
5. Fetch `/feed/` – gated articles carry their full body rather than the gate excerpt, even with Advanced settings → Restrict feeds left on.
6. With WCM active instead: behavior identical to trunk (WCM path untouched).
