### PR TITLE
feat(admin): reachable settings surface for the Google client ID on AC-only sites (NPPD-2104)

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -45,7 +45,7 @@ class Admin_Settings {
 	public static function init() {
 		add_action( 'admin_menu', array( __CLASS__, 'register_settings_page' ) );
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
-		add_filter( 'plugin_action_links_' . self::get_plugin_basename(), array( __CLASS__, 'add_settings_action_link' ) );
+		add_filter( 'plugin_action_links_' . self::get_plugin_basename(), array( __CLASS__, 'add_settings_action_link' ), 10, 1 );
 	}
 
 	/**
@@ -137,13 +137,15 @@ class Admin_Settings {
 		// The callback runs on every update of the option (it is hooked to
 		// sanitize_option_*), so the admin-only settings-error API may be
 		// unavailable, e.g. under WP-CLI.
-		if ( '' !== $value && ! filter_var( $value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) && function_exists( 'add_settings_error' ) ) {
-			// The callback can run twice for a single save (when the option
-			// row does not exist yet, update_option falls through to
-			// add_option and the sanitizer runs again), so only add the
-			// warning if it is not already queued.
+		if ( '' !== $value && ! DependencyChecker::is_valid_client_id( $value ) && function_exists( 'add_settings_error' ) ) {
+			// The callback can run twice for a single save (when the option row
+			// does not exist yet, update_option falls through to add_option and
+			// the sanitizer runs again), so only warn if it is not already
+			// queued. The queue global is read directly rather than through
+			// get_settings_errors(), which deletes the settings_errors transient
+			// as a side effect on a request carrying settings-updated=true.
 			$already_warned = false;
-			foreach ( get_settings_errors( self::GOOGLE_CLIENT_API_ID_OPTION ) as $settings_error ) {
+			foreach ( $GLOBALS['wp_settings_errors'] ?? array() as $settings_error ) {
 				if ( 'invalid_google_client_api_id' === $settings_error['code'] ) {
 					$already_warned = true;
 					break;
@@ -172,13 +174,15 @@ class Admin_Settings {
 	 * Render the Google Client API ID field.
 	 */
 	public static function render_google_client_api_id_field() {
+		// A half-migrated install can have a malformed home URL, and a settings
+		// page that warns about PHP notices instead of rendering is worse than
+		// one that shows a slightly odd origin.
 		$home_url_parts    = wp_parse_url( home_url() );
-		$allowed_referrers = $home_url_parts['scheme'] . '://' . $home_url_parts['host'];
+		$allowed_referrers = ( $home_url_parts['scheme'] ?? 'https' ) . '://' . ( $home_url_parts['host'] ?? '' );
 		// A non-standard port is part of the origin Google must allow.
 		if ( ! empty( $home_url_parts['port'] ) ) {
 			$allowed_referrers .= ':' . $home_url_parts['port'];
 		}
-		$allowed_referrers = esc_url( $allowed_referrers );
 		?>
 		<input
 			type="text"
@@ -204,7 +208,10 @@ class Admin_Settings {
 					)
 				),
 				'https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid',
-				esc_url( $allowed_referrers )
+				// Rendered as text, not as an href, so it must survive verbatim:
+				// this is the exact string to paste into Google's Authorized
+				// JavaScript origins.
+				esc_html( $allowed_referrers )
 			);
 			?>
 		</p>
@@ -216,7 +223,7 @@ class Admin_Settings {
 	 */
 	public static function render_settings_page() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
+			wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'newspack-extended-access' ), 403 );
 		}
 		?>
 		<div class="wrap">

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Standalone wp-admin settings page for the plugin.
+ *
+ * @package Newspack\ExtendedAccess
+ */
+
+namespace Newspack\ExtendedAccess;
+
+/**
+ * Registers a settings page under the wp-admin Settings menu.
+ *
+ * This is the plugin's canonical configuration surface. It works with any
+ * content gating system: unlike the WooCommerce settings section (see
+ * WC_Settings_Memberships_Option_Tab), it remains reachable on sites gated by
+ * Newspack Access Control, where WooCommerce Memberships is deactivated and
+ * the wc-settings Memberships tab does not exist. Both surfaces read and
+ * write the same option.
+ */
+class Admin_Settings {
+
+	/**
+	 * Option storing the Google Client API ID.
+	 */
+	const GOOGLE_CLIENT_API_ID_OPTION = 'newspack_extended_access__google_client_api_id';
+
+	/**
+	 * Settings page slug.
+	 */
+	const PAGE_SLUG = 'newspack-extended-access';
+
+	/**
+	 * Settings group.
+	 */
+	const SETTINGS_GROUP = 'newspack_extended_access';
+
+	/**
+	 * Settings section id.
+	 */
+	const SECTION_ID = 'newspack_extended_access_google';
+
+	/**
+	 * Set up hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', array( __CLASS__, 'register_settings_page' ) );
+		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+		add_filter( 'plugin_action_links_' . self::get_plugin_basename(), array( __CLASS__, 'add_settings_action_link' ) );
+	}
+
+	/**
+	 * Get the plugin basename, e.g. `newspack-extended-access/newspack-extended-access.php`.
+	 *
+	 * @return string The plugin basename.
+	 */
+	protected static function get_plugin_basename(): string {
+		return plugin_basename( dirname( __DIR__ ) . '/newspack-extended-access.php' );
+	}
+
+	/**
+	 * Get the URL of the settings page.
+	 *
+	 * @return string The settings page URL.
+	 */
+	public static function get_settings_url(): string {
+		return admin_url( 'options-general.php?page=' . self::PAGE_SLUG );
+	}
+
+	/**
+	 * Add a Settings link to the plugin's row on the Plugins page.
+	 *
+	 * @param string[] $links The plugin action links.
+	 * @return string[] The action links with the Settings link prepended.
+	 */
+	public static function add_settings_action_link( $links ) {
+		$settings_link = '<a href="' . esc_url( self::get_settings_url() ) . '">' . esc_html__( 'Settings', 'newspack-extended-access' ) . '</a>';
+		array_unshift( $links, $settings_link );
+		return $links;
+	}
+
+	/**
+	 * Register the settings page under the Settings menu.
+	 */
+	public static function register_settings_page() {
+		add_options_page(
+			__( 'Newspack Extended Access', 'newspack-extended-access' ),
+			__( 'Extended Access', 'newspack-extended-access' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Register the setting, its section, and its field.
+	 */
+	public static function register_settings() {
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::GOOGLE_CLIENT_API_ID_OPTION,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_google_client_api_id' ),
+				'default'           => '',
+			)
+		);
+
+		add_settings_section(
+			self::SECTION_ID,
+			__( 'Google Extended Access', 'newspack-extended-access' ),
+			array( __CLASS__, 'render_section_description' ),
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			self::GOOGLE_CLIENT_API_ID_OPTION,
+			__( 'Google Client API ID', 'newspack-extended-access' ),
+			array( __CLASS__, 'render_google_client_api_id_field' ),
+			self::PAGE_SLUG,
+			self::SECTION_ID,
+			array( 'label_for' => self::GOOGLE_CLIENT_API_ID_OPTION )
+		);
+	}
+
+	/**
+	 * Sanitize the Google Client API ID.
+	 *
+	 * An invalid-looking value is still saved (matching the WooCommerce
+	 * settings surface), but a warning is surfaced because the plugin stays
+	 * dormant until the option holds a valid hostname-shaped client ID.
+	 *
+	 * @param mixed $value The raw submitted value.
+	 * @return string The sanitized value.
+	 */
+	public static function sanitize_google_client_api_id( $value ) {
+		$value = trim( sanitize_text_field( (string) $value ) );
+		// The callback runs on every update of the option (it is hooked to
+		// sanitize_option_*), so the admin-only settings-error API may be
+		// unavailable, e.g. under WP-CLI.
+		if ( '' !== $value && ! filter_var( $value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) && function_exists( 'add_settings_error' ) ) {
+			// The callback can run twice for a single save (when the option
+			// row does not exist yet, update_option falls through to
+			// add_option and the sanitizer runs again), so only add the
+			// warning if it is not already queued.
+			$already_warned = false;
+			foreach ( get_settings_errors( self::GOOGLE_CLIENT_API_ID_OPTION ) as $settings_error ) {
+				if ( 'invalid_google_client_api_id' === $settings_error['code'] ) {
+					$already_warned = true;
+					break;
+				}
+			}
+			if ( ! $already_warned ) {
+				add_settings_error(
+					self::GOOGLE_CLIENT_API_ID_OPTION,
+					'invalid_google_client_api_id',
+					__( 'The Google Client API ID does not look valid. It should look like 1234567890-abcdef.apps.googleusercontent.com. Extended Access will remain inactive until a valid ID is saved.', 'newspack-extended-access' ),
+					'warning'
+				);
+			}
+		}
+		return $value;
+	}
+
+	/**
+	 * Render the section description.
+	 */
+	public static function render_section_description() {
+		echo '<p>' . esc_html__( 'An integration for utilizing Google Extended Access.', 'newspack-extended-access' ) . '</p>';
+	}
+
+	/**
+	 * Render the Google Client API ID field.
+	 */
+	public static function render_google_client_api_id_field() {
+		$home_url_parts    = wp_parse_url( home_url() );
+		$allowed_referrers = $home_url_parts['scheme'] . '://' . $home_url_parts['host'];
+		// A non-standard port is part of the origin Google must allow.
+		if ( ! empty( $home_url_parts['port'] ) ) {
+			$allowed_referrers .= ':' . $home_url_parts['port'];
+		}
+		$allowed_referrers = esc_url( $allowed_referrers );
+		?>
+		<input
+			type="text"
+			id="<?php echo esc_attr( self::GOOGLE_CLIENT_API_ID_OPTION ); ?>"
+			name="<?php echo esc_attr( self::GOOGLE_CLIENT_API_ID_OPTION ); ?>"
+			value="<?php echo esc_attr( get_option( self::GOOGLE_CLIENT_API_ID_OPTION, '' ) ); ?>"
+			class="large-text code"
+			placeholder="1234567890-abcdef.apps.googleusercontent.com"
+		/>
+		<p class="description">
+			<?php
+			printf(
+				/* translators: 1: Google developer documentation link, 2: site origin to allow. */
+				wp_kses(
+					__( 'Refer to the <a href="%1$s" target="_blank">Google Developer Documents</a> to set up and configure your Google Client API ID. Make sure to add your domain <b><u>%2$s</u></b> to Authorized JavaScript origins.', 'newspack-extended-access' ),
+					array(
+						'a' => array(
+							'href'   => array(),
+							'target' => array(),
+						),
+						'b' => array(),
+						'u' => array(),
+					)
+				),
+				'https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid',
+				esc_url( $allowed_referrers )
+			);
+			?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public static function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( self::SETTINGS_GROUP );
+				do_settings_sections( self::PAGE_SLUG );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/includes/class-dependencychecker.php
+++ b/includes/class-dependencychecker.php
@@ -165,14 +165,26 @@ class DependencyChecker {
 	}
 
 	/**
-	 * Check whether Google Client API ID is valid or not.
+	 * Check whether a Google Client API ID looks valid.
+	 *
+	 * The single definition of "valid", so the settings page warns about
+	 * exactly the values that keep this plugin dormant. Tightening the rule
+	 * here tightens the warning with it, rather than letting the admin claim a
+	 * value is fine while the plugin refuses to initialize on it.
+	 *
+	 * @param string $client_id The Google Client API ID to check.
+	 * @return bool Return true if the ID is valid.
+	 */
+	public static function is_valid_client_id( string $client_id ): bool {
+		return (bool) filter_var( $client_id, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME );
+	}
+
+	/**
+	 * Check whether a valid Google Client API ID is stored.
 	 *
 	 * @return bool Return true if valid Google Client API ID is present.
 	 */
 	public static function is_valid_google_client_api_id(): bool {
-		if ( filter_var( get_option( 'newspack_extended_access__google_client_api_id', '' ), FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) ) {
-			return true;
-		}
-		return false;
+		return self::is_valid_client_id( (string) get_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, '' ) );
 	}
 }

--- a/includes/class-google-extendedaccess.php
+++ b/includes/class-google-extendedaccess.php
@@ -159,7 +159,7 @@ class Google_ExtendedAccess {
 					'nonce'             => wp_create_nonce( 'wp_rest' ),
 					'allowedReferrers'  => $allowed_referrers,
 					'postID'            => get_the_ID(),
-					'googleClientApiID' => get_option( 'newspack_extended_access__google_client_api_id', '' ),
+					'googleClientApiID' => get_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, '' ),
 					'myAccountURL'      => $my_account_url,
 				)
 			);

--- a/includes/class-google-jwt.php
+++ b/includes/class-google-jwt.php
@@ -171,7 +171,7 @@ class Google_Jwt {
 
 		// Validate the token.
 		$token_api_id         = $decoded->azp;
-		$google_client_api_id = get_option( 'newspack_extended_access__google_client_api_id', '' );
+		$google_client_api_id = get_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, '' );
 		if ( $token_api_id !== $google_client_api_id ) {
 			return new \WP_Error( 'newspack_extended_access_google_token', __( 'Invalid token', 'newspack-extended-access' ), array( 'status' => 403 ) );
 		}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -29,6 +29,7 @@ class Initializer {
 		// Initialize non-dependency classes.
 		WooCommerce::init();
 		WC_Settings_Memberships_Option_Tab::init();
+		Admin_Settings::init();
 
 		// Defer the dependency-gated initialization until all plugins are
 		// loaded: the Newspack Access Control classes belong to the Newspack
@@ -67,6 +68,13 @@ class Initializer {
 	 * Displays admin notice summarizing error.
 	 */
 	public static function show_admin_notice__error() {
+		// The settings page is where the missing configuration gets fixed; a
+		// notice pointing back at it would be noise there.
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( $current_screen && 'settings_page_' . Admin_Settings::PAGE_SLUG === $current_screen->id ) {
+			return;
+		}
+
 		$plugin_notice = '';
 		$allowed_html  = array(
 			'a'    => array(
@@ -82,9 +90,11 @@ class Initializer {
 			if ( DependencyChecker::is_wc_memberships_stack_active() ) {
 				$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Please check your <b>Google Client API ID</b> into <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=memberships&section=newspack-extended-access' ) ) . '">Newspack Extended Access Settings</a>.';
 			} else {
-				// Without WooCommerce Memberships there is no settings screen for
-				// this option; point at the option itself until one exists.
-				$plugin_notice = '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Set the <code>newspack_extended_access__google_client_api_id</code> option to your Google Client API ID, e.g. via WP-CLI: <code>wp option update newspack_extended_access__google_client_api_id your-client-id.apps.googleusercontent.com</code>.';
+				$plugin_notice = sprintf(
+					/* translators: %s: URL of the Extended Access settings page. */
+					__( '<b>Newspack Extended Access</b> plugin requires <b>Google Client API ID</b> to be configured. Please add your <b>Google Client API ID</b> in <a href="%s">Extended Access Settings</a>.', 'newspack-extended-access' ),
+					esc_url( Admin_Settings::get_settings_url() )
+				);
 			}
 		}
 

--- a/includes/woocommerce/memberships/settings/class-wc-settings-memberships-option-tab.php
+++ b/includes/woocommerce/memberships/settings/class-wc-settings-memberships-option-tab.php
@@ -69,7 +69,7 @@ class WC_Settings_Memberships_Option_Tab {
 
 				array(
 					'type'    => 'textarea',
-					'id'      => 'newspack_extended_access__google_client_api_id',
+					'id'      => \Newspack\ExtendedAccess\Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION,
 					'name'    => __( 'Google Client API ID', 'newspack-extended-access' ),
 					'desc'    => $input_desc,
 					'default' => '',

--- a/tests/unit-tests/test-admin-settings.php
+++ b/tests/unit-tests/test-admin-settings.php
@@ -23,6 +23,12 @@ class Newspack_Test_Admin_Settings extends WP_UnitTestCase {
 		require_once ABSPATH . 'wp-admin/includes/template.php';
 		// Settings errors accumulate in a global that persists across tests.
 		$GLOBALS['wp_settings_errors'] = array();
+		// So does the admin menu, so a page registered by one test would still
+		// be found by the next one and mask a failed registration.
+		$GLOBALS['menu']              = array();
+		$GLOBALS['submenu']           = array();
+		$GLOBALS['_registered_pages'] = array();
+		$GLOBALS['_parent_pages']     = array();
 		delete_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION );
 	}
 
@@ -45,6 +51,36 @@ class Newspack_Test_Admin_Settings extends WP_UnitTestCase {
 			$settings_page_url,
 			'The URL the admin notice links to must be the registered page URL.'
 		);
+	}
+
+	/**
+	 * The page holds a credential for an authentication flow, so the capability
+	 * bar is part of its contract rather than an implementation detail. Locking
+	 * it down here means a later refactor that widens the capability, or drops
+	 * the guard in the render callback as "redundant with add_options_page",
+	 * cannot keep the suite green.
+	 */
+	public function test_settings_page_not_registered_for_non_admins() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		Admin_Settings::register_settings_page();
+
+		$this->assertEmpty(
+			menu_page_url( Admin_Settings::PAGE_SLUG, false ),
+			'A reader-level user must not get the Extended Access settings page in their menu.'
+		);
+	}
+
+	/**
+	 * Rendering is guarded independently of the menu registration, so reaching
+	 * the page URL directly is refused rather than served.
+	 */
+	public function test_render_settings_page_refuses_non_admins() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->expectException( 'WPDieException' );
+
+		Admin_Settings::render_settings_page();
 	}
 
 	/**

--- a/tests/unit-tests/test-admin-settings.php
+++ b/tests/unit-tests/test-admin-settings.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests the standalone wp-admin settings page.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\ExtendedAccess\Admin_Settings;
+
+/**
+ * Tests the Admin_Settings surface: menu registration, option sanitization,
+ * and field rendering. This surface must work without WooCommerce
+ * Memberships, so no WCM stack is loaded here.
+ */
+class Newspack_Test_Admin_Settings extends WP_UnitTestCase {
+
+	/**
+	 * Setup for the tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// The settings-error API lives in an admin-only include.
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+		// Settings errors accumulate in a global that persists across tests.
+		$GLOBALS['wp_settings_errors'] = array();
+		delete_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION );
+	}
+
+	/**
+	 * The settings page is registered under the Settings menu for admins.
+	 */
+	public function test_settings_page_registered_for_admins() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		Admin_Settings::register_settings_page();
+
+		$settings_page_url = menu_page_url( Admin_Settings::PAGE_SLUG, false );
+		$this->assertStringContainsString(
+			'options-general.php?page=' . Admin_Settings::PAGE_SLUG,
+			$settings_page_url,
+			'The settings page must be registered as a Settings submenu page.'
+		);
+		$this->assertSame(
+			Admin_Settings::get_settings_url(),
+			$settings_page_url,
+			'The URL the admin notice links to must be the registered page URL.'
+		);
+	}
+
+	/**
+	 * Saving the option runs the sanitize callback registered via
+	 * register_setting: markup is stripped and whitespace trimmed.
+	 */
+	public function test_option_save_is_sanitized() {
+		Admin_Settings::register_settings();
+
+		update_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, "  <b>1234-abc.apps.googleusercontent.com</b>\n" );
+
+		$this->assertSame(
+			'1234-abc.apps.googleusercontent.com',
+			get_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION ),
+			'The stored client ID must be stripped of markup and surrounding whitespace.'
+		);
+	}
+
+	/**
+	 * An invalid-looking client ID is still saved (matching the WooCommerce
+	 * surface) but surfaces a settings-error warning.
+	 */
+	public function test_invalid_client_id_saves_with_warning() {
+		$sanitized_value = Admin_Settings::sanitize_google_client_api_id( 'not a hostname' );
+
+		$this->assertSame( 'not a hostname', $sanitized_value, 'An invalid value must still be saved.' );
+
+		$settings_errors = get_settings_errors( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION );
+		$this->assertCount( 1, $settings_errors, 'An invalid value must surface exactly one settings error.' );
+		$this->assertSame( 'warning', $settings_errors[0]['type'], 'The settings error must be a warning, not a hard failure.' );
+	}
+
+	/**
+	 * A first-ever save of an invalid value warns exactly once, although the
+	 * sanitize callback runs twice (update_option on a missing option row
+	 * falls through to add_option, which sanitizes again).
+	 */
+	public function test_first_ever_save_of_invalid_value_warns_once() {
+		Admin_Settings::register_settings();
+
+		update_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, 'not a hostname' );
+
+		$this->assertSame(
+			'not a hostname',
+			get_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION ),
+			'The invalid value must still be saved on first-ever save.'
+		);
+		$this->assertCount(
+			1,
+			get_settings_errors( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION ),
+			'The invalid-value warning must be queued exactly once even when the sanitizer runs twice.'
+		);
+	}
+
+	/**
+	 * A valid client ID produces no settings error.
+	 */
+	public function test_valid_client_id_saves_without_warning() {
+		$sanitized_value = Admin_Settings::sanitize_google_client_api_id( '1234-abc.apps.googleusercontent.com' );
+
+		$this->assertSame( '1234-abc.apps.googleusercontent.com', $sanitized_value );
+		$this->assertCount(
+			0,
+			get_settings_errors( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION ),
+			'A valid value must not surface a settings error.'
+		);
+	}
+
+	/**
+	 * The field renders the stored value in an input named after the option.
+	 */
+	public function test_field_renders_option_value() {
+		update_option( Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION, '1234-abc.apps.googleusercontent.com' );
+
+		ob_start();
+		Admin_Settings::render_google_client_api_id_field();
+		$field_html = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'name="' . Admin_Settings::GOOGLE_CLIENT_API_ID_OPTION . '"',
+			$field_html,
+			'The input must post back to the option name.'
+		);
+		$this->assertStringContainsString(
+			'value="1234-abc.apps.googleusercontent.com"',
+			$field_html,
+			'The input must be pre-filled with the stored client ID.'
+		);
+	}
+}

--- a/tests/unit-tests/test-api-rest-controller.php
+++ b/tests/unit-tests/test-api-rest-controller.php
@@ -8,10 +8,14 @@
 use Newspack\ExtendedAccess;
 
 require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
+require_once dirname( __FILE__ ) . '/utils/trait-hook-snapshot.php';
 /**
  * Tests REST API Controller.
  */
 class Newspack_Test_API_Controller extends WP_UnitTestCase {
+
+	use Newspack_Hook_Snapshot;
+
 	/**
 	 * Plugin slug/folder.
 	 *
@@ -38,6 +42,12 @@ class Newspack_Test_API_Controller extends WP_UnitTestCase {
 		echo esc_html( 'Initializing Newspack for test...' . PHP_EOL );
 		\Newspack\Data_Events\Webhooks::init();
 		do_action( 'init' );
+
+		// The Newspack plugin's hooks were registered just now, so let the next
+		// set_up() re-take the snapshot tear_down() restores from - otherwise
+		// they are stripped after this class's first test whenever another test
+		// class ran first. See the trait for the full mechanism.
+		self::reset_hook_snapshot();
 
 		echo esc_html( 'Initializing testing...' . PHP_EOL );
 	}

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -504,6 +504,46 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 	}
 
 	/**
+	 * On an Access Control site (WCM inactive) with no client ID configured,
+	 * the admin notice links to the standalone settings page - the reachable
+	 * surface - rather than the unreachable wc-settings Memberships tab.
+	 */
+	public function test_missing_client_id_notice_links_to_settings_page() {
+		delete_option( 'newspack_extended_access__google_client_api_id' );
+
+		ob_start();
+		Initializer::show_admin_notice__error();
+		$notice_html = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'options-general.php?page=' . \Newspack\ExtendedAccess\Admin_Settings::PAGE_SLUG,
+			$notice_html,
+			'The missing-client-ID notice must link to the standalone settings page.'
+		);
+		$this->assertStringNotContainsString(
+			'wc-settings',
+			$notice_html,
+			'The notice must not point at the WooCommerce settings tab when WCM is inactive.'
+		);
+	}
+
+	/**
+	 * The missing-client-ID notice is suppressed on the settings page itself,
+	 * where it would only point back at the page the admin is already on.
+	 */
+	public function test_missing_client_id_notice_suppressed_on_settings_page() {
+		delete_option( 'newspack_extended_access__google_client_api_id' );
+
+		set_current_screen( 'settings_page_' . \Newspack\ExtendedAccess\Admin_Settings::PAGE_SLUG );
+		ob_start();
+		Initializer::show_admin_notice__error();
+		$notice_html = ob_get_clean();
+		set_current_screen( 'front' );
+
+		$this->assertSame( '', $notice_html, 'No notice must render on the Extended Access settings page itself.' );
+	}
+
+	/**
 	 * The LD+JSON schema reports a gated post as not accessible for free.
 	 */
 	public function test_ld_json_marks_gated_post_as_not_free() {

--- a/tests/unit-tests/test-integration-access-control.php
+++ b/tests/unit-tests/test-integration-access-control.php
@@ -12,6 +12,7 @@ use Newspack\ExtendedAccess\REST_Controller;
 use Newspack\ExtendedAccess\SinglePost_Subscription;
 
 require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
+require_once dirname( __FILE__ ) . '/utils/trait-hook-snapshot.php';
 
 /**
  * Tests that unlocks granted via Google Extended Access are honored by the
@@ -28,6 +29,8 @@ require_once dirname( __FILE__ ) . '/utils/class-plugin-manager.php';
  * at-sign in this docblock - PHPUnit parses it from prose.)
  */
 class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
+
+	use Newspack_Hook_Snapshot;
 
 	/**
 	 * The Newspack plugin release the suite is verified against. Pinned so the
@@ -66,6 +69,12 @@ class Newspack_Test_Integration_Access_Control extends WP_UnitTestCase {
 		// The plugin loaded after the bootstrap fired 'init'; fire it again so
 		// init-dependent registrations (e.g. default access rules) run.
 		do_action( 'init' );
+
+		// The Newspack plugin's hooks were registered just now, so let the next
+		// set_up() re-take the snapshot tear_down() restores from - otherwise
+		// they are stripped after this class's first test whenever another test
+		// class ran first. See the trait for the full mechanism.
+		self::reset_hook_snapshot();
 
 		// Enable the Access Control feature flag. Content_Gate re-reads the
 		// constant on every call when IS_TEST_ENV is defined.

--- a/tests/unit-tests/utils/trait-hook-snapshot.php
+++ b/tests/unit-tests/utils/trait-hook-snapshot.php
@@ -16,13 +16,47 @@
  * class runs before it, the plugin is loaded too late for the snapshot and its
  * hooks vanish from the second test onwards. Discarding the snapshot right
  * after the plugin is loaded makes the class independent of that ordering.
+ *
+ * The snapshot being discarded lives on WP_UnitTestCase_Base and is shared by
+ * every class in the phpunit process, so a bare reset would rebase the baseline
+ * for all classes running afterwards rather than only the resetting one. The
+ * prior snapshot is therefore captured and put back in tear_down_after_class(),
+ * keeping the widened baseline scoped to the class that asked for it: a class
+ * running later still starts from the baseline it would have had, so a test
+ * asserting on a clean hook environment cannot pass alone and fail in the full
+ * run because of a reset three files away.
+ *
+ * Requires the using class to extend WP_UnitTestCase, which is where the
+ * snapshot property is declared.
+ *
+ * @see WP_UnitTestCase_Base::$hooks_saved
  */
 trait Newspack_Hook_Snapshot {
+
+	/**
+	 * The hook snapshot as it stood before this class reset it.
+	 *
+	 * @var array|null
+	 */
+	protected static $hooks_saved_before_reset = null;
 
 	/**
 	 * Discard the hook snapshot so the next set_up() re-takes it.
 	 */
 	protected static function reset_hook_snapshot() {
-		self::$hooks_saved = array();
+		self::$hooks_saved_before_reset = self::$hooks_saved;
+		self::$hooks_saved              = array();
+	}
+
+	/**
+	 * Put back the snapshot this class replaced, so the widened baseline does
+	 * not leak into classes that run afterwards in the same process.
+	 */
+	public static function tear_down_after_class() {
+		if ( null !== self::$hooks_saved_before_reset ) {
+			self::$hooks_saved              = self::$hooks_saved_before_reset;
+			self::$hooks_saved_before_reset = null;
+		}
+		parent::tear_down_after_class();
 	}
 }

--- a/tests/unit-tests/utils/trait-hook-snapshot.php
+++ b/tests/unit-tests/utils/trait-hook-snapshot.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Hook snapshot control for test classes that load a plugin mid-run.
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * Lets a test class re-take the WP_UnitTestCase hook snapshot.
+ *
+ * WP_UnitTestCase snapshots $wp_filter on the first set_up() of the phpunit
+ * process and restores it in every tear_down(), so any hook registered after
+ * that snapshot is stripped once the first test of the process finishes. A
+ * test class that loads a plugin in set_up_before_class() therefore keeps that
+ * plugin's hooks only while it is the first class to run - as soon as another
+ * class runs before it, the plugin is loaded too late for the snapshot and its
+ * hooks vanish from the second test onwards. Discarding the snapshot right
+ * after the plugin is loaded makes the class independent of that ordering.
+ */
+trait Newspack_Hook_Snapshot {
+
+	/**
+	 * Discard the hook snapshot so the next set_up() re-takes it.
+	 */
+	protected static function reset_hook_snapshot() {
+		self::$hooks_saved = array();
+	}
+}


### PR DESCRIPTION
## What

Adds a **Settings → Extended Access** page (WordPress Settings API, `manage_options`) holding the plugin's one config field — the Google Client API ID — writing the existing `newspack_extended_access__google_client_api_id` option. The missing-client-ID admin notice on AC-only sites now links to this page instead of printing a WP-CLI stopgap command. Discoverable via the Settings menu, the notice link, and a "Settings" action link on the plugins screen.

Closes NPPD-2104.

## Why

On a site migrated to Access Control (WooCommerce Memberships deactivated), the only existing config UI — the "Newspack Extended Access" section of the WCM Woo settings tab — disappears, leaving WP-CLI as the only way to set the client ID.

## Design notes

- The Linear-suggested candidate (AC wizard Advanced Settings modal) has no extension point at any layer (PHP settings array, REST config keys, React modal) — hosting the field there would require a newspack-plugin PR adding a filter + REST schema + JS extension point for one field. A standalone Settings page needs zero newspack-plugin changes.
- The WCM Woo settings tab is untouched: sites still on Memberships keep their existing surface; both write the same option.
- Invalid-looking values save with a warning (matching the Woo tab's behavior) rather than being rejected; the sanitize callback is idempotent across WP's first-save double-sanitize and CLI-safe.
- Side effect: registering the setting means values saved via the Woo tab now pass the same `sanitize_text_field`+`trim` — this cannot mangle any value `FILTER_VALIDATE_DOMAIN` accepts; at worst it repairs stray whitespace.

## Test harness fix

`WP_UnitTestCase` snapshots `$wp_filter` on the first `set_up()` of the phpunit process and restores it in every `tear_down()`, so hooks registered after that snapshot are stripped from the second test onwards. The Access Control suite only worked because the class that loads the Newspack plugin (`Newspack_Test_API_Controller`) happened to be the first test file alphabetically; adding `test-admin-settings.php` displaced it and the Access Control gate tests started failing under CI's single-process `vendor/bin/phpunit` run. A `Newspack_Hook_Snapshot` trait now discards the snapshot right after the plugin is loaded, in both classes that load it, making them independent of class order.

## Stacking

Based on #23 (NPPD-1901) — **merge #23 first**. AC-only operation (DependencyChecker accepting Access Control without WCM) only exists there.

## Testing

On an AC-only site (WCM inactive, `NEWSPACK_CONTENT_GATES` on, RAS on, EA active):
1. Dashboard shows the missing-ID notice linking to Settings → Extended Access; the page renders the field with Google-setup guidance (including the site's JS origin, port-aware).
2. Save a client ID → `wp option get newspack_extended_access__google_client_api_id` returns it; the notice disappears.
3. Save an invalid value (with the option row absent for the first-save case) → exactly one warning notice; value stored; missing-ID notice returns.
4. The notice does not render on the settings page itself.

Suites: Newspack Test Suite OK (23 tests, 41 assertions); Access Control Integration OK (19 tests, 29 assertions). Both suites in one process, as CI runs them: OK (42 tests, 70 assertions). PHPCS toolchain in this repo is broken independently of this PR (NPPD-2105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myjt7Uvz86A2TvSomqrhE1
